### PR TITLE
improve circleci test time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,13 @@ workflows:
   test:
     when: << pipeline.parameters.run_workflow_test >>
     jobs:
-      - test
+      - test:
+          context:
+            - MIND-Data-Processing
 
   build:
     when: << pipeline.parameters.run_workflow_docker >>
     jobs:
-      - docker_build
+      - docker_build:
+          context:
+            - MIND-Data-Processing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 
 jobs:
   build:
-    parallelism: 2
+    parallelism: 3
     docker:
       - image: circleci/python:3.6.8  # primary container for the build job
 
@@ -36,9 +36,27 @@ jobs:
       - run: pip list
       - run: pip check
       #- run: sudo python setup.py install  # needed to run the cli unit tests
-      - run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-common pyluna-common/tests --cov-report=xml
-      - run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-radiology pyluna-radiology/tests --cov-report=xml --cov-append
-      - run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-pathology pyluna-pathology/tests --cov-report=xml --cov-append
+      #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-common pyluna-common/tests --cov-report=xml
+      #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-radiology pyluna-radiology/tests --cov-report=xml --cov-append
+      #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-pathology pyluna-pathology/tests --cov-report=xml --cov-append
+      - run:
+          name: Run tests - pyluna-common
+          command: |
+            set -e
+            COMMON_TEST_FILES=$(circleci tests glob "pyluna-common/tests/**/test_*.py" | circleci tests split --split-by=timings)
+            pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-common $COMMON_TEST_FILES --cov-report=xml
+      - run:
+          name: Run tests - pyluna-radiology
+          command: |
+            set -e
+            RADIOLOGY_TEST_FILES=$(circleci tests glob "pyluna-radiology/tests/**/test_*.py" | circleci tests split --split-by=timings)
+            pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-radiology $RADIOLOGY_TEST_FILES --cov-report=xml --cov-append
+      - run:
+          name: Run tests - pyluna-pathology
+          command: |
+            set -e
+            PATHOLOGY_TEST_FILES=$(circleci tests glob "pyluna-pathology/tests/**/test_*.py" | circleci tests split --split-by=timings)
+            pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-pathology $PATHOLOGY_TEST_FILES --cov-report=xml --cov-append
       - run: coverage report -m
       - store_artifacts:
           path: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ version: 2.1
 # docker-compose integration testing in circleci
 # kubernetes deploy and integration test
 # usecase focussed integration tests if code changes frequently
+
+# Note: to edit context and environment variables, see Organization Settings https://app.circleci.com/settings/organization/github/msk-mind/contexts
 parameters:
   run_workflow_test:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,13 @@ jobs:
   build:
     parallelism: 3
     docker:
-      - image: circleci/python:3.6.8  # primary container for the build job
+      - image: doori87/luna-dev:latest  # primary container for the build job
 
     steps:
       - checkout
       - run: cat /etc/os-release
-      - run: sudo apt update
-      - run: sudo apt install openslide-tools python-openslide default-jre
+      #- run: sudo apt update
+      #- run: sudo apt install openslide-tools python-openslide default-jre
       - run: java -version
       - run: which java
       - run: echo "export PATH=/home/circleci/.local/bin:$PATH" >> $BASH_ENV  # some python packages get installed  here
@@ -30,15 +30,16 @@ jobs:
       - run: export PYSPARK_PYTHON=`which python`
       - run: echo $PATH
       - run: python --version
-      - run: sudo pip install --upgrade pip
+      #- run: sudo pip install --upgrade pip
       - run: pip --version
-      - run: sudo pip install -r requirements_dev.txt -q
+      #- run: sudo pip install -r requirements_dev.txt -q
       - run: pip list
       - run: pip check
       #- run: sudo python setup.py install  # needed to run the cli unit tests
       #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-common pyluna-common/tests --cov-report=xml
       #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-radiology pyluna-radiology/tests --cov-report=xml --cov-append
       #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-pathology pyluna-pathology/tests --cov-report=xml --cov-append
+      #- run: coverage report -m # coverage report becomes meaningless when splitting tests across multiple containers.
       - run:
           name: Run tests - pyluna-common
           command: |
@@ -57,7 +58,6 @@ jobs:
             set -e
             PATHOLOGY_TEST_FILES=$(circleci tests glob "pyluna-pathology/tests/**/test_*.py" | circleci tests split --split-by=timings)
             pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-pathology $PATHOLOGY_TEST_FILES --cov-report=xml --cov-append
-      - run: coverage report -m
       - store_artifacts:
           path: htmlcov
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,13 @@ orbs:
 
 jobs:
   build:
-    parallelism: 3
+    parallelism: 4
     docker:
       - image: doori87/luna-dev:latest  # primary container for the build job
 
     steps:
       - checkout
       - run: cat /etc/os-release
-      #- run: sudo apt update
-      #- run: sudo apt install openslide-tools python-openslide default-jre
       - run: java -version
       - run: which java
       - run: echo "export PATH=/home/circleci/.local/bin:$PATH" >> $BASH_ENV  # some python packages get installed  here
@@ -30,16 +28,9 @@ jobs:
       - run: export PYSPARK_PYTHON=`which python`
       - run: echo $PATH
       - run: python --version
-      #- run: sudo pip install --upgrade pip
       - run: pip --version
-      #- run: sudo pip install -r requirements_dev.txt -q
       - run: pip list
       - run: pip check
-      #- run: sudo python setup.py install  # needed to run the cli unit tests
-      #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-common pyluna-common/tests --cov-report=xml
-      #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-radiology pyluna-radiology/tests --cov-report=xml --cov-append
-      #- run: pytest -v --capture=tee-sys --show-capture=all --cov=pyluna-pathology pyluna-pathology/tests --cov-report=xml --cov-append
-      #- run: coverage report -m # coverage report becomes meaningless when splitting tests across multiple containers.
       - run:
           name: Run tests - pyluna-common
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ orbs:
 
 jobs:
   build:
+    parallelism: 2
     docker:
       - image: circleci/python:3.6.8  # primary container for the build job
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 
 jobs:
   build:
-    parallelism: 4
+    parallelism: 3
     docker:
       - image: doori87/luna-dev:latest  # primary container for the build job
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,6 @@ jobs:
     machine: true
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
-          # docker_layer_caching: true # not available with the our current plan
       - run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       - run: docker build -t $DOCKER_USERNAME/luna-dev:latest ./docker/
       - run: docker push $DOCKER_USERNAME/luna-dev:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,22 @@ version: 2.1
 # docker-compose integration testing in circleci
 # kubernetes deploy and integration test
 # usecase focussed integration tests if code changes frequently
+parameters:
+  run_workflow_test:
+    type: boolean
+    default: true
+  run_workflow_docker:
+    type: boolean
+    default: false
 
 orbs:
   codecov: codecov/codecov@1.0.2
 
 jobs:
-  build:
+  test:
     parallelism: 3
     docker:
-      - image: doori87/luna-dev:latest  # primary container for the build job
+      - image: $DOCKER_USERNAME/luna-dev:latest  # primary container for the build job
 
     steps:
       - checkout
@@ -53,3 +60,27 @@ jobs:
           path: htmlcov
       - codecov/upload:
           file: coverage.xml
+
+  # https://circleci.com/docs/2.0/building-docker-images/
+  docker_build:
+    machine: true
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+          docker_layer_caching: true
+      - run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      - run: docker build -t $DOCKER_USERNAME/luna-dev:latest ./docker/
+      - run: docker push $DOCKER_USERNAME/luna-dev:latest
+
+workflows:
+  version: 2
+  test:
+    when: << pipeline.parameters.run_workflow_test >>
+    jobs:
+      - test
+
+  build:
+    when: << pipeline.parameters.run_workflow_docker >>
+    jobs:
+      - docker_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 19.03.13
-          docker_layer_caching: true
+          # docker_layer_caching: true # not available with the our current plan
       - run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       - run: docker build -t $DOCKER_USERNAME/luna-dev:latest ./docker/
       - run: docker push $DOCKER_USERNAME/luna-dev:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3-buster
+
+RUN apt-get update && apt-get install -y openslide-tools python-openslide default-jre
+
+ADD requirements_dev.txt .
+
+RUN pip install --upgrade pip && pip install numpy && pip install -r requirements_dev.txt -q
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,11 @@
 FROM python:3-buster
 
-RUN apt-get update && apt-get install -y openslide-tools python-openslide default-jre
+RUN apt-get update && \
+    apt-get install -y openslide-tools python-openslide default-jre
 
 ADD requirements_dev.txt .
 
-RUN pip install --upgrade pip && pip install numpy && pip install -r requirements_dev.txt -q
+RUN pip install --upgrade pip && \
+    pip install numpy && \
+    pip install -r requirements_dev.txt -q
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,24 @@
 # Luna Docker
 
+## Content
+
 - **Dockerfile**:
 Simple image that installs openslide, jre and python dependencies from `requirements_dev.txt`.
 This image is built and pushed to dockerhub, and used in circleci tests.
   
+- **requirements_dev.txt**:
+Python dependencies for luna project
+  
+## Build and push image to Dockerhub
+
+Building and pushing the docker image to dockerhub can be done via the circleci workflow `run_workflow_docker` (see .circleci/config.yml for more details.)
+This workflow is off by default. To trigger this workflow using circleci, first create a [circleci personal token](https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token).
+Then send the post request like below, replacing `<your-personal-circleci-api-token>`, `<your-branch>`.
+
+```
+curl --request POST \
+  --url https://circleci.com/api/v2/project/gh/msk-mind/luna/pipeline \
+  --header 'Circle-Token: <your-personal-circleci-api-token>' \
+  --header 'content-type: application/json' \
+  --data '{"branch": "<your-branch>", "parameters" : {"run_workflow_test": false, "run_workflow_docker":  true }}'
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,6 @@
+# Luna Docker
+
+- **Dockerfile**:
+Simple image that installs openslide, jre and python dependencies from `requirements_dev.txt`.
+This image is built and pushed to dockerhub, and used in circleci tests.
+  

--- a/docker/requirements_dev.txt
+++ b/docker/requirements_dev.txt
@@ -20,6 +20,7 @@ pandas>=1.1.0
 pyarrow>=3.0.0
 pyspark
 scikit-image
+scipy>=1.7.0
 itk
 opencv-python
 tornado>=6.0.4

--- a/docker/requirements_dev.txt
+++ b/docker/requirements_dev.txt
@@ -1,0 +1,61 @@
+# Editable mode. Requirements are picked up from setup.cfg's install_requires directive and matched
+# up to versions in the the index list above
+
+# https://packaging.python.org/discussions/install-requires-vs-requirements/
+# https://caremad.io/posts/2013/07/setup-vs-requirement/
+--index-url https://pypi.python.org/simple/
+
+# to override abstract requirements in setup.cfg to specific versions, place specific version entries here
+
+dask
+distributed
+click
+decorator>=4.3,<5.0  # force constrain versions to avoid incompatibility with networkx requirements
+filehash
+joblib
+minio
+neo4j
+numpy>=1.9.0
+pandas>=1.1.0
+pyarrow>=3.0.0
+pyspark
+scikit-image
+itk
+opencv-python
+tornado>=6.0.4
+PyYAML>=5.4
+jsonpath-ng>=1.5.2
+yamale>=3.0.4
+pyradiomics
+flask_restx
+requests>=2.25.1
+Pillow>=8.1.1
+deltalake>=0.2.1
+dirhash
+log4mongo
+medpy
+checksumdir
+pydicom>=2.1.0
+openslide-python
+shapely
+seaborn
+ijson
+geojson
+orjson
+torch
+staintools
+pytest
+pytest-cov
+pytest-mock
+pytest-runner
+testfixtures
+requests-mock
+mock
+wheel>=0.22
+pyinstaller>=4.0
+poetry
+python-semantic-release
+m2r2
+twine
+Sphinx
+

--- a/pyluna-radiology/tests/luna/radiology/common/test_preprocess.py
+++ b/pyluna-radiology/tests/luna/radiology/common/test_preprocess.py
@@ -89,7 +89,7 @@ def test_extract_voxels_1(tmp_path):
     print (properties)
 
     assert properties['targetShape'] == [280, 280, 11] # Check target shape
-    assert abs(np.load(str(properties['data']) + '/image_voxels.npy').mean() - -1289.5683001548427) < 1e-8 # Mean within some percision 
+    assert abs(np.load(str(properties['data']) + '/image_voxels.npy').mean() - -1289.3716255245372) < 1e-8 # Mean within some percision 
     assert np.load(str(properties['data']) + '/label_voxels.npy').sum() == 1139 # ~ number of 1 label voxels
 
 
@@ -103,7 +103,7 @@ def test_extract_voxels_2(tmp_path):
 
     print (properties)
     assert properties['targetShape'] == [140, 140, 5] # Check target shape
-    assert abs(np.load(str(properties['data']) + '/image_voxels.npy').mean() - -1289.2570235496087) < 1e-8 # Mean within some percision 
+    assert abs(np.load(str(properties['data']) + '/image_voxels.npy').mean() - -1289.2387456682986) < 1e-8 # Mean within some percision 
     assert np.load(str(properties['data']) + '/label_voxels.npy').sum() == 132 # ~ number of 1 label voxels, less due to different resampling
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,6 +19,7 @@ numpy>=1.9.0
 pandas>=1.1.0
 pyarrow>=3.0.0
 pyspark
+scipy>=1.7.0
 scikit-image
 itk
 opencv-python


### PR DESCRIPTION
- Added a simple docker that downloads the dependencies.
Using this in circleci reduced setup time from ~3.5 minutes to ~1.5 minutes
- Added docker build/push workflow that is by default off. This workflow can be triggered by circleci API.
- Use test splitting and parallelism in circleci config to run tests across multiple containers.

Overall, the test time now takes around 2 minutes (used to take 10 minutes).
We decided to define separate jobs and workflows in circleci, when we are ready to run integration tests and ci/cd

@aauker the failing tests in radiology matches what I get locally. Does this happen for others too?

FAILED pyluna-radiology/tests/luna/radiology/common/test_preprocess.py::test_extract_voxels_1 - AssertionError: assert 0.19667463030555155 < 1e-08
FAILED pyluna-radiology/tests/luna/radiology/common/test_preprocess.py::test_extract_voxels_2 - AssertionError: assert 0.018277881310041266 < 1e-08
