### PR TITLE
fix: Inference Model

### DIFF
--- a/pyluna-common/luna/common/CodeTimer.py
+++ b/pyluna-common/luna/common/CodeTimer.py
@@ -17,3 +17,5 @@ class CodeTimer:
     def __exit__(self, exc_type, exc_value, traceback):
         self.took = (timeit.default_timer() - self.start)
         self.logger.info('Code block' + self.name + ' took: ' + str(self.took) + 's')
+        if exc_type is not None:
+            self.logger.exception("Exception raised during code execution:")

--- a/pyluna-common/luna/common/custom_logger.py
+++ b/pyluna-common/luna/common/custom_logger.py
@@ -16,7 +16,6 @@ class MultilineFormatter(logging.Formatter):
         record.message = output
         return output
 
-
 def init_logger(filename='data-processing.log'):
     # Logging configuration
     if os.environ['LUNA_HOME']:

--- a/pyluna-common/luna/common/utils.py
+++ b/pyluna-common/luna/common/utils.py
@@ -342,11 +342,7 @@ def cli_runner(cli_kwargs: dict, cli_params: List[tuple], cli_function: Callable
     # Nice little log break
     print("\n" + "-"*35 + f' Running transform::{cli_function.__name__} ' + "-" *35 + "\n")
 
-    try:
-        result = cli_function(**kwargs)
-    except Exception as exc:
-        logger.exception(f"Raised exception - {exc}")
-        result = {'status':'failed'}
+    result = cli_function(**kwargs)
     
     kwargs.update(result)
 

--- a/pyluna-common/luna/common/utils.py
+++ b/pyluna-common/luna/common/utils.py
@@ -342,7 +342,11 @@ def cli_runner(cli_kwargs: dict, cli_params: List[tuple], cli_function: Callable
     # Nice little log break
     print("\n" + "-"*35 + f' Running transform::{cli_function.__name__} ' + "-" *35 + "\n")
 
-    result = cli_function(**kwargs)
+    try:
+        result = cli_function(**kwargs)
+    except Exception as exc:
+        logger.exception(f"Raised exception - {exc}")
+        result = {'status':'failed'}
     
     kwargs.update(result)
 

--- a/pyluna-common/luna/common/utils.py
+++ b/pyluna-common/luna/common/utils.py
@@ -342,7 +342,7 @@ def cli_runner(cli_kwargs: dict, cli_params: List[tuple], cli_function: Callable
     # Nice little log break
     print("\n" + "-"*35 + f' Running transform::{cli_function.__name__} ' + "-" *35 + "\n")
 
-    with CodeTimer(logger, f'Run transform::{cli_function.__name__}'):
+    with CodeTimer(logger, name=f'transform::{cli_function.__name__}'):
         result = cli_function(**kwargs)
     
     kwargs.update(result)

--- a/pyluna-common/luna/common/utils.py
+++ b/pyluna-common/luna/common/utils.py
@@ -342,7 +342,8 @@ def cli_runner(cli_kwargs: dict, cli_params: List[tuple], cli_function: Callable
     # Nice little log break
     print("\n" + "-"*35 + f' Running transform::{cli_function.__name__} ' + "-" *35 + "\n")
 
-    result = cli_function(**kwargs)
+    with CodeTimer(logger, f'Run transform::{cli_function.__name__}'):
+        result = cli_function(**kwargs)
     
     kwargs.update(result)
 

--- a/pyluna-common/luna/common/utils.py
+++ b/pyluna-common/luna/common/utils.py
@@ -246,8 +246,8 @@ def validate_params(given_params: dict, params_list: List[tuple]):
             else:
                 raise RuntimeError(f"Type {type(dtype)} invalid!")
 
-        except ValueError:
-            raise RuntimeError(f"Param {name} could not be cast to {dtype}")
+        except ValueError as exc:
+            raise RuntimeError(f"Param {name} could not be cast to {dtype} - {exc}")
 
         except RuntimeError as e:
             raise e

--- a/pyluna-common/luna/common/utils.py
+++ b/pyluna-common/luna/common/utils.py
@@ -342,8 +342,7 @@ def cli_runner(cli_kwargs: dict, cli_params: List[tuple], cli_function: Callable
     # Nice little log break
     print("\n" + "-"*35 + f' Running transform::{cli_function.__name__} ' + "-" *35 + "\n")
 
-    with CodeTimer(logger, name=f'transform::{cli_function.__name__}'):
-        result = cli_function(**kwargs)
+    result = cli_function(**kwargs)
     
     kwargs.update(result)
 

--- a/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
+++ b/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
@@ -10,7 +10,7 @@ logger = logging.getLogger('infer_tile_labels')
 
 from luna.common.utils import cli_runner
 
-_params_ = [('input_slide_tiles', str), ('output_dir', str), ('hub_repo_or_dir', str), ('model_name', str), ('num_cores', int), ('batch_size', int)]
+_params_ = [('input_slide_tiles', str), ('output_dir', str), ('hub_repo_or_dir', str), ('model_name', str), ('kwargs', json), ('num_cores', int), ('batch_size', int)]
 
 @click.command()
 @click.argument('input_slide_tiles', nargs=1)
@@ -22,8 +22,8 @@ _params_ = [('input_slide_tiles', str), ('output_dir', str), ('hub_repo_or_dir',
               help="torch hub transform name")   
 @click.option('-mn', '--model_name', required=False,
               help="torch hub model name")    
-@click.option('-wt', '--weight_tag', required=False,
-              help="weight tag filename")  
+@click.option('-kw', '--kwargs', required=False,
+              help="additional keywords to pass to model initialization", default='{}')  
 @click.option('-nc', '--num_cores', required=False,
               help="Number of cores to use", default=4)  
 @click.option('-bx', '--batch_size', required=False,
@@ -57,7 +57,7 @@ from luna.pathology.common.ml import HD5FDataset, TorchTransformModel
 
 import pandas as pd
 from tqdm import tqdm
-def infer_tile_labels(input_slide_tiles, output_dir, hub_repo_or_dir, model_name, num_cores, batch_size):
+def infer_tile_labels(input_slide_tiles, output_dir, hub_repo_or_dir, model_name, num_cores, batch_size, kwargs):
     """Run inference using a model and transform definition (either local or using torch.hub)
 
     Decorates existing slide_tiles with additional columns corresponding to class prediction/scores from the model
@@ -82,7 +82,7 @@ def infer_tile_labels(input_slide_tiles, output_dir, hub_repo_or_dir, model_name
     else:
         source = 'github'
 
-    clf = torch.hub.load(hub_repo_or_dir, model_name, source=source)
+    clf = torch.hub.load(hub_repo_or_dir, model_name, source=source, **kwargs)
 
     if not (isinstance(clf, nn.Module) or isinstance(clf, TorchTransformModel)):
         raise RuntimeError("Not a valid model!")

--- a/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
+++ b/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
@@ -1,6 +1,5 @@
 # General imports
 import os, json, logging, yaml, sys
-from numpy import isin
 import click
 
 from luna.common.custom_logger   import init_logger

--- a/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
+++ b/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
@@ -98,9 +98,6 @@ def infer_tile_labels(input_slide_tiles, output_dir, hub_repo_or_dir, model_name
         preprocess = clf.get_preprocess()
         transform  = clf.transform
         clf.model.to(device)
-    else: # In this case, we are just worthin with a pure torch.nn module
-        preprocess = nn.Identity()
-        transform = clf.to(device)
 
     df     = pd.read_csv(input_slide_tiles).set_index('address')
     ds     = HD5FDataset(df, preprocess=preprocess)

--- a/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
+++ b/pyluna-pathology/luna/pathology/cli/infer_tile_labels.py
@@ -81,6 +81,8 @@ def infer_tile_labels(input_slide_tiles, output_dir, hub_repo_or_dir, model_name
     else:
         source = 'github'
 
+    logger.info(f"Source={source}")
+
     clf = torch.hub.load(hub_repo_or_dir, model_name, source=source, **kwargs)
 
     if not (isinstance(clf, nn.Module) or isinstance(clf, TorchTransformModel)):

--- a/pyluna-pathology/luna/pathology/common/ml.py
+++ b/pyluna-pathology/luna/pathology/common/ml.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Union, Tuple, List
 
 from PIL import Image
 # from sklearn.model_selection._split import _BaseKFold, _RepeatedSplits
-from sklearn.model_selection import StratifiedGroupKFold
+#from sklearn.model_selection import StratifiedGroupKFold
 from sklearn.utils.validation import check_random_state
 from torch import nn
 from torch.utils.data import Dataset, DataLoader
@@ -82,7 +82,7 @@ def post_transform_to_2d(input: torch.Tensor) -> np.array:
     Args:
         input (torch.tensor): tensor input of shape [B, *] where B is the batch dimension
     """
-    if not len(input.shape)==1: 
+    if not len(input.shape)==2: 
         warnings.warn(f'Reshaping model output (was {input.shape}) to 2D')
         return input.view(input.shape[0], -1).cpu().numpy()
     else:

--- a/pyluna-pathology/luna/pathology/common/ml.py
+++ b/pyluna-pathology/luna/pathology/common/ml.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Union, Tuple, List
 
 from PIL import Image
 # from sklearn.model_selection._split import _BaseKFold, _RepeatedSplits
-#from sklearn.model_selection import StratifiedGroupKFold
+from sklearn.model_selection import StratifiedGroupKFold
 from sklearn.utils.validation import check_random_state
 from torch import nn
 from torch.utils.data import Dataset, DataLoader

--- a/pyluna-pathology/luna/pathology/common/ml.py
+++ b/pyluna-pathology/luna/pathology/common/ml.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Union, Tuple, List
 
 from PIL import Image
 # from sklearn.model_selection._split import _BaseKFold, _RepeatedSplits
-# from sklearn.model_selection import StratifiedGroupKFold
+from sklearn.model_selection import StratifiedGroupKFold
 from sklearn.utils.validation import check_random_state
 from torch import nn
 from torch.utils.data import Dataset, DataLoader

--- a/pyluna-pathology/luna/pathology/common/ml.py
+++ b/pyluna-pathology/luna/pathology/common/ml.py
@@ -18,7 +18,28 @@ from torchmetrics import MetricCollection
 
 from luna.pathology.common.utils import get_tile_array
 
-class TorchTransformModel: pass
+class TorchTransformModel: 
+    def get_preprocess(self, **kwargs):
+        """The transform model's preprocessing code
+
+        Args:
+            kwargs: Keyword arguements passed onto the subclass method
+        """
+        raise NotImplementedError("get_preprocess() has not been implimented in the subclass!")
+
+    def transform(self, X: torch.Tensor):
+        """Main transformer method, X -> X'
+
+        Args:
+            X (torch.Tensor): input tensor
+
+        Returns:
+            torch.tensor: Output tile as preprocessed tensor
+        """ 
+        raise NotImplementedError("transform() has not been implimented in the subclass!")    
+    
+    
+    pass
 
 class HD5FDataset(Dataset):
     """ General dataset that uses a HDF5 manifest convention

--- a/pyluna-pathology/luna/pathology/common/ml.py
+++ b/pyluna-pathology/luna/pathology/common/ml.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Union, Tuple, List
 
 from PIL import Image
 # from sklearn.model_selection._split import _BaseKFold, _RepeatedSplits
-#from sklearn.model_selection import StratifiedGroupKFold
+from sklearn.model_selection import StratifiedGroupKFold
 from sklearn.utils.validation import check_random_state
 from torch import nn
 from torch.utils.data import Dataset, DataLoader

--- a/pyluna-pathology/luna/pathology/common/utils.py
+++ b/pyluna-pathology/luna/pathology/common/utils.py
@@ -415,7 +415,7 @@ def get_scale_factor_at_magnfication(slide: openslide.OpenSlide,
     return scale_factor
 
 def visualize_tiling_scores(df:pd.DataFrame, thumbnail_img:np.ndarray, scale_factor:float,
-        score_type_to_visualize:str) -> np.ndarray:
+        score_type_to_visualize:str, normalize=True) -> np.ndarray:
     """visualize tile scores
     
     draws colored boxes around tiles to indicate the value of the score 
@@ -432,6 +432,9 @@ def visualize_tiling_scores(df:pd.DataFrame, thumbnail_img:np.ndarray, scale_fac
     """
 
     assert isinstance(thumbnail_img, np.ndarray)
+
+    if normalize:
+        df[score_type_to_visualize] = (df[score_type_to_visualize] - np.min(df[score_type_to_visualize]))/np.ptp(df[score_type_to_visualize])
 
     for _, row in tqdm(df.iterrows(), total=len(df)):
 

--- a/pyluna-pathology/luna/pathology/schemas.py
+++ b/pyluna-pathology/luna/pathology/schemas.py
@@ -7,6 +7,7 @@ class SlideTiles:
     REQ_COLUMNS = set(['address', 'tile_size', 'tile_units', 'x_coord', 'y_coord'])
     @classmethod
     def check(self, slide_tiles):
+        """Returns True if the given path is readable as "SlideTiles <slide_tiles>", else, reaises SchemaMismatchError"""
         df = pd.read_csv(slide_tiles)
 
         if not set(df.columns).intersection(self.REQ_COLUMNS) == self.REQ_COLUMNS:

--- a/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
@@ -15,7 +15,6 @@ def test_cli(tmp_path):
             '-mn', 'testmodel',
             ])
 
-    # No longer error gracefully -- can update tests with proper data and they'll work
     assert result.exit_code == 0
 
     assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 14)
@@ -32,7 +31,6 @@ def test_cli_kwargs(tmp_path):
             '-kw', '{"n_channels":10}'
             ])
 
-    # No longer error gracefully -- can update tests with proper data and they'll work
     assert result.exit_code == 0
 
     assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 16)

--- a/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
@@ -3,6 +3,7 @@ from click.testing import CliRunner
 from luna.pathology.cli.infer_tile_labels import cli
 
 import pandas as pd
+from luna.pathology.schemas import SlideTiles
 
 def test_cli(tmp_path):
 
@@ -12,10 +13,11 @@ def test_cli(tmp_path):
             'pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123/',
             '-o', tmp_path,
             '-rn', 'pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub',
-            '-mn', 'testmodel',
+            '-mn', 'test_custom_model',
             ])
 
     assert result.exit_code == 0
+    assert SlideTiles.check(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv")
 
     assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 14)
 
@@ -27,11 +29,31 @@ def test_cli_kwargs(tmp_path):
             'pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123/',
             '-o', tmp_path,
             '-rn', 'pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub',
-            '-mn', 'testmodel',
+            '-mn', 'test_custom_model',
             '-kw', '{"n_channels":10}'
             ])
 
     assert result.exit_code == 0
+    assert SlideTiles.check(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv")
 
     assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 16)
+
+def test_cli_resnet(tmp_path):
+
+    runner = CliRunner()
+
+    result = runner.invoke(cli, [
+            'pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123/',
+            '-o', tmp_path,
+            '-rn', 'pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub',
+            '-mn', 'test_resnet',
+            '-kw', '{"depth": 18, "pretrained":true}'
+            ])
+
+    assert result.exit_code == 0
+    assert SlideTiles.check(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv")
+
+    assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 1006)
+
+
 

--- a/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
@@ -19,7 +19,12 @@ def test_cli(tmp_path):
     assert result.exit_code == 0
     assert SlideTiles.check(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv")
 
-    assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 14)
+    # Default to 2 channels..
+    df = pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv")
+    assert df.shape == (12, 8)
+
+    assert set(['Background', 'Tumor']).intersection(set(df.columns)) == set(['Background', 'Tumor'])
+    
 
 def test_cli_kwargs(tmp_path):
 
@@ -36,7 +41,8 @@ def test_cli_kwargs(tmp_path):
     assert result.exit_code == 0
     assert SlideTiles.check(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv")
 
-    assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 16)
+    df = pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv")
+    assert df.shape == (12, 16) # 8 more
 
 def test_cli_resnet(tmp_path):
 

--- a/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
@@ -19,3 +19,21 @@ def test_cli(tmp_path):
     assert result.exit_code == 0
 
     assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 14)
+
+def test_cli_kwargs(tmp_path):
+
+    runner = CliRunner()
+
+    result = runner.invoke(cli, [
+            'pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123/',
+            '-o', tmp_path,
+            '-rn', 'pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub',
+            '-mn', 'testmodel',
+            '-kw', '{"n_channels":10}'
+            ])
+
+    # No longer error gracefully -- can update tests with proper data and they'll work
+    assert result.exit_code == 0
+
+    assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 16)
+

--- a/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/test_infer_tile_labels.py
@@ -2,19 +2,20 @@ from click.testing import CliRunner
 
 from luna.pathology.cli.infer_tile_labels import cli
 
+import pandas as pd
 
 def test_cli(tmp_path):
 
     runner = CliRunner()
 
     result = runner.invoke(cli, [
-            'pyluna-pathology/tests/luna/pathology/cli/testdata/data/test/slides/123/test_generate_tile_ov_labels/TileImages/data/',
+            'pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123/',
             '-o', tmp_path,
-            '-rn', 'msk-mind/luna-ml',
-            '-tn', 'tissue_tile_net_transform',
-            '-mn', 'tissue_tile_net_model_5_class',
-            '-wt', 'main:tissue_net_2021-01-19_21.05.24-e17.pth',
+            '-rn', 'pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub',
+            '-mn', 'testmodel',
             ])
 
     # No longer error gracefully -- can update tests with proper data and they'll work
-    assert result.exit_code == 1
+    assert result.exit_code == 0
+
+    assert pd.read_csv(f"{tmp_path}/tile_scores_and_labels_pytorch_inference.csv").shape == (12, 14)

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/infer_tumor_background/123/metadata.yml
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/infer_tumor_background/123/metadata.yml
@@ -1,0 +1,17 @@
+available_labels:
+- x_coord
+- y_coord
+- tile_image_file
+- tile_size
+- tile_units
+- Background
+- Tumor
+batch_size: 64
+hub_repo_or_dir: pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub
+input_slide_tiles: pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.csv
+kwargs: {}
+model_name: test_custom_model
+num_cores: 4
+output_dir: pyluna-pathology/tests/luna/pathology/cli/testdata/data/infer_tumor_background/123/
+slide_tiles: pyluna-pathology/tests/luna/pathology/cli/testdata/data/infer_tumor_background/123/tile_scores_and_labels_pytorch_inference.csv
+total_tiles: 12

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/infer_tumor_background/123/tile_scores_and_labels_pytorch_inference.csv
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/infer_tumor_background/123/tile_scores_and_labels_pytorch_inference.csv
@@ -1,0 +1,13 @@
+address,x_coord,y_coord,tile_image_file,tile_size,tile_units,Background,Tumor
+x1_y1_z10.0,512.0,512.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.67729187,-0.9070499
+x1_y2_z10.0,512.0,1024.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.6319428,-0.84757584
+x1_y3_z10.0,512.0,1536.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.61218035,-0.82392985
+x1_y4_z10.0,512.0,2048.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.5603356,-0.7596926
+x2_y1_z10.0,1024.0,512.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.38840988,-0.5942302
+x2_y2_z10.0,1024.0,1024.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.36021793,-0.56911147
+x2_y3_z10.0,1024.0,1536.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.35513628,-0.56647706
+x2_y4_z10.0,1024.0,2048.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.4442727,-0.62332517
+x3_y1_z10.0,1536.0,512.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.6586894,-0.8959336
+x3_y2_z10.0,1536.0,1024.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.5618485,-0.7990217
+x3_y3_z10.0,1536.0,1536.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.6383263,-0.86979014
+x3_y4_z10.0,1536.0,2048.0,pyluna-pathology/tests/luna/pathology/cli/testdata/data/generate_tiles/123//123.tiles.h5,512.0,px,0.5518583,-0.750212

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
@@ -18,6 +18,6 @@ class MyModel(TorchTransformModel):
     def transform(self, X):
         X = X.permute(0, 3, 1, 2).float()
         out = self.model(X).view(X.shape[0], -1)
-        return out.cpu().numpy()
+        return out
 
 def testmodel(n_channels=8): return MyModel(n_channels)

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
@@ -12,11 +12,14 @@ class MyCustomModel(TorchTransformModel):
             nn.AdaptiveAvgPool2d((1,1))
         )
 
+        if n_channels == 2:
+            self.class_labels = {0:'Background', 1:'Tumor'}
+
     def get_preprocess(self):
         return self.preprocess
 
     def transform(self, X):
-        X = X.permute(0, 3, 1, 2).float()
+        X = X.permute(0, 3, 1, 2).float() / 255
         out = self.model(X).view(X.shape[0], -1)
         return out
 
@@ -32,10 +35,10 @@ class Resnet(TorchTransformModel):
         return self.preprocess
 
     def transform(self, X):
-        X = X.permute(0, 3, 1, 2).float()
+        X = X.permute(0, 3, 1, 2).float() / 255
         out = self.model(X).view(X.shape[0], -1)
         return out
 
 
-def test_custom_model(n_channels=8): return MyCustomModel(n_channels)
+def test_custom_model(n_channels=2): return MyCustomModel(n_channels)
 def test_resnet(**kwargs): return Resnet(**kwargs)

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
@@ -3,7 +3,7 @@ from torch import nn
 
 from luna.pathology.common.ml import TorchTransformModel
 
-class MyModel(TorchTransformModel):
+class MyCustomModel(TorchTransformModel):
     preprocess = nn.Identity()
 
     def __init__(self, n_channels):
@@ -20,4 +20,22 @@ class MyModel(TorchTransformModel):
         out = self.model(X).view(X.shape[0], -1)
         return out
 
-def testmodel(n_channels=8): return MyModel(n_channels)
+class Resnet(TorchTransformModel):
+    preprocess = nn.Identity()
+
+    def __init__(self, depth, pretrained):
+        # del kwargs['depth']
+        self.model =  torch.hub.load('pytorch/vision:v0.10.0', f'resnet{depth}', pretrained=pretrained)
+
+
+    def get_preprocess(self):
+        return self.preprocess
+
+    def transform(self, X):
+        X = X.permute(0, 3, 1, 2).float()
+        out = self.model(X).view(X.shape[0], -1)
+        return out
+
+
+def test_custom_model(n_channels=8): return MyCustomModel(n_channels)
+def test_resnet(**kwargs): return Resnet(**kwargs)

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
@@ -1,0 +1,25 @@
+import torch
+from torch import nn
+from  torchvision import transforms
+
+from luna.pathology.common.ml import TorchTransformModel
+
+class MyModel(TorchTransformModel):
+    preprocess = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.ConvertImageDtype(torch.float)
+    ])
+
+    model = nn.Sequential(
+        nn.Conv2d(3, 8, kernel_size=3),
+        nn.AdaptiveAvgPool2d((1,1))
+    )
+
+    def get_preprocess(self):
+        return self.preprocess
+
+    def transform(self, X):
+        out = self.model(X).view(X.shape[0], -1)
+        return out.cpu().numpy()
+
+def testmodel(): return MyModel()

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
@@ -10,10 +10,11 @@ class MyModel(TorchTransformModel):
         transforms.ConvertImageDtype(torch.float)
     ])
 
-    model = nn.Sequential(
-        nn.Conv2d(3, 8, kernel_size=3),
-        nn.AdaptiveAvgPool2d((1,1))
-    )
+    def __init__(self, n_channels):
+        self.model = nn.Sequential(
+            nn.Conv2d(3, n_channels, kernel_size=3),
+            nn.AdaptiveAvgPool2d((1,1))
+        )
 
     def get_preprocess(self):
         return self.preprocess
@@ -22,4 +23,4 @@ class MyModel(TorchTransformModel):
         out = self.model(X).view(X.shape[0], -1)
         return out.cpu().numpy()
 
-def testmodel(): return MyModel()
+def testmodel(n_channels=8): return MyModel(n_channels)

--- a/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
+++ b/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py
@@ -1,14 +1,10 @@
 import torch
 from torch import nn
-from  torchvision import transforms
 
 from luna.pathology.common.ml import TorchTransformModel
 
 class MyModel(TorchTransformModel):
-    preprocess = transforms.Compose([
-        transforms.ToTensor(),
-        transforms.ConvertImageDtype(torch.float)
-    ])
+    preprocess = nn.Identity()
 
     def __init__(self, n_channels):
         self.model = nn.Sequential(
@@ -20,6 +16,7 @@ class MyModel(TorchTransformModel):
         return self.preprocess
 
     def transform(self, X):
+        X = X.permute(0, 3, 1, 2).float()
         out = self.model(X).view(X.shape[0], -1)
         return out.cpu().numpy()
 


### PR DESCRIPTION
* Introduced a more general class HD5FDataset(Dataset):
* New schema called TorchTransformModel, where the preprocess and transform methods are defined together (and optionally, the class label mapping)
* Tests work, using SlideSchema validated on output
* Recursive use of torch.hub is possible, see `luna/pyluna-pathology/tests/luna/pathology/cli/testdata/data/testhub/hubconf.py` where vision/resnet is used within the TorchTransformModel class
* Plus some fixes to error handling