### PR TITLE
fix: adding requirements for xnat etl

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -74,3 +74,5 @@ docker
 pre-commit
 ipykernel # ipykernel for docs
 tabulate
+pyxnat
+xmltodict


### PR DESCRIPTION
minor fix to add `pyxnat` and `xlmtodict` to requirements. no need to fix versions, pretty simple dependencies. 