### PR TITLE
1501 fix tutorials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
         run: |
           . ./venv/bin/activate
           export LUNA_HOME=$PWD
+          # added to fix: detected dubious ownership in repository at '/__w/luna/luna'
+          git config --global --add safe.directory /__w/luna/luna
           mkdocs gh-deploy --force
 
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,11 @@ jobs:
           mkdocs build
 
       - name: Deploy mkdocs
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        #if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         run: |
           . ./venv/bin/activate
           export LUNA_HOME=$PWD
+          git config --global --add safe.directory .
           mkdocs gh-deploy --force
 
   deploy:


### PR DESCRIPTION
Testing fix to mkdocs build, strange error:
```
ERROR    -  Failed to deploy to GitHub with error: 
Deployment Aborted!
detected dubious ownership in repository at '/__w/luna/luna'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/luna/luna
```