### PR TITLE
1532 add no copy

### DIFF
--- a/src/luna/common/utils.py
+++ b/src/luna/common/utils.py
@@ -181,9 +181,21 @@ def rebase_schema_numeric(df):
 
         df[col] = df[col].astype(float, errors="ignore")
 
+def rebase_schema_mixed(df):
+    """
+    Tries to convert all columns with mixed types to strings.
 
-#        df[col] = df[col].astype(int, errors="ignore") # This was converting small floats to integers...
+    Note: this is an in-place operation
 
+    Args:
+        df (pd.DataFrame): dataframe to convert columns
+    """
+    for col in df.columns:
+        mixed = (df[[col]].applymap(type) != df[[col]].iloc[0].apply(type)).any(axis=1)
+        if len(df[mixed]) > 0:
+            df[col] = df[col].astype(str)
+        if df[col].dtype == list:
+            df[col] = df[col].astype(str)
 
 def generate_uuid_binary(content, prefix):
     """

--- a/src/luna/pathology/cli/slide_etl.py
+++ b/src/luna/pathology/cli/slide_etl.py
@@ -11,9 +11,14 @@ from loguru import logger
 from multimethod import multimethod
 from pandera.typing import DataFrame
 from tiffslide import TiffSlide
-
 from luna.common.models import Slide, SlideSchema
-from luna.common.utils import apply_csv_filter, get_config, timed, rebase_schema_numeric, rebase_schema_mixed
+from luna.common.utils import (
+    apply_csv_filter, 
+    get_config, 
+    timed, 
+    rebase_schema_numeric, 
+    rebase_schema_mixed,
+)
 from luna.pathology.common.utils import (
     get_downscaled_thumbnail,
     get_scale_factor_at_magnification,
@@ -21,7 +26,6 @@ from luna.pathology.common.utils import (
 )
 
 VALID_SLIDE_EXTENSIONS = [".svs", ".scn", ".tif"]
-
 
 @timed
 def cli(
@@ -48,10 +52,8 @@ def cli(
         output_urlpath (str): url/path to output table
         output_storage_options (dict): storage options to pass to writing functions
         local_config (str): url/path to YAML config file
+        no_copy (bool): determines whether we copy slides to output_urlpath
 
-
-    Returns:
-        slide (Slide): slide object
     """
 
     config = get_config(vars())
@@ -110,6 +112,22 @@ def slide_etl(
     output_storage_options: dict = {},
     no_copy: bool = False
 ) -> DataFrame:
+    """Ingest slides by adding them to a file or s3 based storage location and generating metadata about them
+
+    Args:
+        slide_url (str): path to slide image
+        project_name (str): project name underwhich the slides should reside
+        comment (str): comment and description of dataset
+        storage_options (dict): storage options to pass to reading functions
+        output_urlpath (str): url/path to output table
+        output_storage_options (dict): storage options to pass to writing functions
+
+
+    Returns:
+        df (DataFrame): dataframe containing the metadata of all the slides
+    """
+
+
     client = get_client()
     sb = SlideBuilder(storage_options, output_storage_options=output_storage_options)
 

--- a/src/luna/pathology/cli/slide_etl.py
+++ b/src/luna/pathology/cli/slide_etl.py
@@ -34,6 +34,7 @@ def cli(
     storage_options: dict = {},
     output_storage_options: dict = {},
     local_config: str = "",
+    no_copy: bool = False
 ):
     """Ingest slide by adding them to a file or s3 based storage location and generating metadata about them
 
@@ -83,6 +84,7 @@ def cli(
         config["storage_options"],
         config["output_urlpath"],
         config["output_storage_options"],
+        config["no_copy"]
     )
 
     # rebase_schema_numeric(df)
@@ -105,6 +107,7 @@ def slide_etl(
     storage_options: dict = {},
     output_urlpath: str = "",
     output_storage_options: dict = {},
+    no_copy: bool = False
 ) -> DataFrame:
     client = get_client()
     sb = SlideBuilder(storage_options, output_storage_options=output_storage_options)
@@ -120,7 +123,7 @@ def slide_etl(
     ]
     progress(futures)
     slides = client.gather(futures)
-    if output_urlpath:
+    if not no_copy and output_urlpath:
         futures = [
             client.submit(
                 sb.copy_slide,
@@ -142,6 +145,7 @@ def slide_etl(
     storage_options: dict = {},
     output_urlpath: str = "",
     output_storage_options: dict = {},
+    no_copy: bool = False
 ) -> Slide:
     """Ingest slide by adding them to a file or s3 based storage location and generating metadata about them
 
@@ -161,7 +165,7 @@ def slide_etl(
     sb = SlideBuilder(storage_options, output_storage_options=output_storage_options)
 
     slide = sb.get_slide(slide_url, project_name=project_name, comment=comment)
-    if output_urlpath:
+    if not no_copy and output_urlpath:
         slide = sb.copy_slide(slide, output_urlpath)
     return slide
 


### PR DESCRIPTION
Adds extra flags to slide_etl cli:
- no_copy: if set to true, then do not copy slides to the output url path
- metadata_extension: allows the user to choose between saving metadata df as a csv or parquet file