### PR TITLE
fix: #1629 improve API for use with dask

### DIFF
--- a/src/luna/common/models.py
+++ b/src/luna/common/models.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pandera as pa
 from pandera.engines.pandas_engine import PydanticModel
 from pandera.typing import Series
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class Slide(BaseModel):
@@ -19,9 +19,9 @@ class Slide(BaseModel):
     channel1_R: Optional[float] = None
     channel1_G: Optional[float] = None
     channel1_B: Optional[float] = None
+    properties: Optional[dict] = None
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class ShapeFeaturesSchema(pa.DataFrameModel):
@@ -47,8 +47,7 @@ class Tile(BaseModel):
     tile_size: int
     tile_units: str
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class StoredTile(Tile):

--- a/src/luna/common/utils.py
+++ b/src/luna/common/utils.py
@@ -2,12 +2,13 @@ import itertools
 import json
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import time
 import urllib
 import warnings
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from functools import wraps
 from importlib import import_module
 from io import BytesIO
@@ -77,8 +78,18 @@ def save_metadata(func):
     return wrapper
 
 
+@contextmanager
+def make_temp_directory():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir)
+
+
 def local_cache_urlpath(
-    file_key_write_mode: dict[str, str] = {}, dir_key_write_mode: dict[str, str] = {}
+    file_key_write_mode: dict[str, str] = {},
+    dir_key_write_mode: dict[str, str] = {},
 ):
     """Decorator for caching url/paths locally"""
 

--- a/src/luna/pathology/cli/dsa_upload.py
+++ b/src/luna/pathology/cli/dsa_upload.py
@@ -137,7 +137,7 @@ def upload_annotation_to_dsa(
         DataFrame[SlideSchema]: slide manifest
     """
     uuids = []
-    for slide in slide_manifest.itertuples(name="Slide"):
+    for _, slide in slide_manifest.iterrows():
         uuids = _upload_annotation_to_dsa(
             dsa_endpoint_url,
             slide[annotation_column],

--- a/src/luna/pathology/cli/dsa_upload.py
+++ b/src/luna/pathology/cli/dsa_upload.py
@@ -136,6 +136,7 @@ def upload_annotation_to_dsa(
     Returns:
         DataFrame[SlideSchema]: slide manifest
     """
+    uuids = []
     for slide in slide_manifest.itertuples(name="Slide"):
         uuids = _upload_annotation_to_dsa(
             dsa_endpoint_url,
@@ -148,10 +149,8 @@ def upload_annotation_to_dsa(
             insecure,
             storage_options,
         )
-        slide_manifest.at[
-            slide.Index, annotation_column.replace("url", "uuid")
-        ] = uuids[0]
-    return slide_manifest
+        uuids.append(uuids[0])
+    return slide_manifest.assign(**{annotation_column: uuids})
 
 
 def _upload_annotation_to_dsa(

--- a/src/luna/pathology/cli/dsa_upload.py
+++ b/src/luna/pathology/cli/dsa_upload.py
@@ -117,9 +117,27 @@ def upload_annotation_to_dsa(
     insecure: bool = False,
     storage_options: dict = {},
 ):
-    uuids = []
+    """Upload annotation to DSA
+
+    Upload json annotation file as a new annotation to the image in the DSA collection.
+
+    Args:
+        dsa_endpoint_url (string): DSA API endpoint e.g. http://localhost:8080/api/v1
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        annotation_column (string): annotation column of slide_manifest containing the dsa url
+        collection_name (string): name of the collection in DSA
+        image_filename (string): name of the image file in DSA e.g. 123.svs. If not specified, infer from annotiaton_file_urpath
+        username (string): DSA username (defaults to environment variable DSA_USERNAME)
+        password (string): DSA password (defaults to environment variable DSA_PASSWORD)
+        force (bool): upload even if annotation with same name exists for the slide
+        insecure (bool): insecure ssl
+        storage_options (dict): options to pass to reading functions
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
     for slide in slide_manifest.itertuples(name="Slide"):
-        uuids += _upload_annotation_to_dsa(
+        uuids = _upload_annotation_to_dsa(
             dsa_endpoint_url,
             slide[annotation_column],
             collection_name,
@@ -130,7 +148,10 @@ def upload_annotation_to_dsa(
             insecure,
             storage_options,
         )
-    return uuids
+        slide_manifest.at[
+            slide.Index, annotation_column.replace("url", "uuid")
+        ] = uuids[0]
+    return slide_manifest
 
 
 def _upload_annotation_to_dsa(

--- a/src/luna/pathology/cli/dsa_viz.py
+++ b/src/luna/pathology/cli/dsa_viz.py
@@ -207,9 +207,7 @@ def stardist_polygon_cli(
 
 def stardist_polygon(
     slide_manifest: DataFrame[SlideSchema],
-    object_urlpath: str,
     output_urlpath: str,
-    image_filename: str,
     annotation_name: str,
     line_colors: Dict[str, str],
     fill_colors: Dict[str, str],
@@ -218,6 +216,22 @@ def stardist_polygon(
     annotation_column: str = "stardist_polygon_geojson_url",
     output_column: str = "regional_dsa_url",
 ):
+    """Build DSA annotation json from stardist geojson classification results
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        output_urlpath (string): URL/path prefix to save annotations
+        annotation_name (string): name of the annotation to be displayed in DSA
+        line_colors (dict): user-provided line color map with {feature name:rgb values}
+        fill_colors (dict): user-provided fill color map with {feature name:rgba values}
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        annotation_column (string): column containing url to stardist polygon geojson
+        output_column (string): column with result url to add to slide_manifest
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
     if annotation_column not in slide_manifest.columns:
         raise ValueError(f"{annotation_column} not found in slide manifest")
     client = get_or_create_dask_client()
@@ -322,6 +336,7 @@ def stardist_polygon_tile_cli(
     line_colors: dict[str, str] = {},
     fill_colors: dict[str, str] = {},
     storage_options: dict = {},
+    output_storage_options: dict = {},
     local_config: str = "",
 ):
     """Build DSA annotation json from stardist geojson classification and labeled tiles
@@ -334,7 +349,8 @@ def stardist_polygon_tile_cli(
         output_urlpath (string): URL/path prefix to save annotations
         line_colors (dict): user-provided line color map with {feature name:rgb values}
         fill_colors (dict): user-provided fill color map with {feature name:rgba values}
-        storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
         local_config (string): local config YAML file
 
     Returns:
@@ -357,10 +373,7 @@ def stardist_polygon_tile_cli(
 
 def stardist_polygon_tile(
     slide_manifest: DataFrame[SlideSchema],
-    object_urlpath: str,
-    tiles_urlpath: str,
     output_urlpath: str,
-    image_filename: str,
     annotation_name_prefix: str,
     line_colors: Dict[str, str],
     fill_colors: Dict[str, str],
@@ -369,6 +382,22 @@ def stardist_polygon_tile(
     annotation_column: str = "stardist_polygon_geojson_url",
     output_column_suffix: str = "regional_dsa_url",
 ):
+    """Build DSA annotation json from stardist geojson classification and labeled tiles
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest
+        annotation_name_prefix (string): name of the annotation to be displayed in DSA
+        output_urlpath (string): URL/path prefix to save annotations
+        line_colors (dict): user-provided line color map with {feature name:rgb values}
+        fill_colors (dict): user-provided fill color map with {feature name:rgba values}
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        annotation_column (string): column containing url to stardist polygon geojson
+        output_column_suffix (string): column suffix with result url to add to slide_manifest
+
+    Returns:
+        dict[str,str]: annotation file path
+    """
     if annotation_column not in slide_manifest.columns:
         raise ValueError(f"{annotation_column} not found in slide manifest")
     client = get_or_create_dask_client()
@@ -415,11 +444,13 @@ def __stardist_polygon_tile(
     Args:
         object_urlpath (string): URL/path to stardist geojson classification results
         tiles_urlpath (string): URL/path to tiles manifest parquet
-        annotation_name_prefix (string): name of the annotation to be displayed in DSA
         output_urlpath (string): URL/path prefix to save annotations
+        image_filename (string): name of the image file in DSA e.g. 123.svs
+        annotation_name_prefix (string): name of the annotation to be displayed in DSA
         line_colors (dict): user-provided line color map with {feature name:rgb values}
         fill_colors (dict): user-provided fill color map with {feature name:rgba values}
-        storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
 
     Returns:
         dict: DSA annotations
@@ -503,6 +534,7 @@ def stardist_cell_cli(
     line_colors: Optional[dict[str, str]] = None,
     fill_colors: Optional[dict[str, str]] = None,
     storage_options: dict = {},
+    output_storage_options: dict = {},
     local_config: str = "",
 ):
     """Build DSA annotation json from TSV classification data generated by
@@ -519,7 +551,8 @@ def stardist_cell_cli(
         annotation_name (string): name of the annotation to be displayed in DSA
         line_colors (dict, optional): line color map with {feature name:rgb values}
         fill_colors (dict, optional): fill color map with {feature name:rgba values}
-        storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
         local_config (string): local config YAML file
 
     Returns:
@@ -542,7 +575,6 @@ def stardist_cell_cli(
 def stardist_cell(
     slide_manifest: DataFrame[SlideSchema],
     output_urlpath: str,
-    image_filename: str,
     annotation_name: str,
     line_colors: Optional[Dict[str, str]],
     fill_colors: Optional[Dict[str, str]],
@@ -551,6 +583,27 @@ def stardist_cell(
     annotation_column: str = "stardist_cell_tsv_url",
     output_column: str = "stardist_cell_dsa_url",
 ):
+    """Build DSA annotation json from TSV classification data generated by
+    stardist
+
+    Processes a cell classification data generated by Qupath/stardist and
+    adds the center coordinates of the cells
+    as annotation elements.
+
+    Args:
+        input_urlpath (string): URL/path to TSV classification data generated by stardist
+        output_urlpath (string): URL/path prefix for saving dsa annotation json
+        annotation_name (string): name of the annotation to be displayed in DSA
+        line_colors (dict, optional): line color map with {feature name:rgb values}
+        fill_colors (dict, optional): fill color map with {feature name:rgba values}
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        annotation_column (string): column containing url to stardist polygon geojson
+        output_column_suffix (string): column suffix with result url to add to slide_manifest
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
     if annotation_column not in slide_manifest.columns:
         raise ValueError(f"{annotation_column} not found in slide manifest")
     client = get_or_create_dask_client()
@@ -671,6 +724,7 @@ def regional_polygon_cli(
     line_colors: Optional[dict[str, str]] = None,
     fill_colors: Optional[dict[str, str]] = None,
     storage_options: dict = {},
+    output_storage_options: dict = {},
     local_config: str = "",
 ):
     """Build DSA annotation json from regional annotation geojson
@@ -681,7 +735,8 @@ def regional_polygon_cli(
         annotation_name (string): name of the annotation to be displayed in DSA
         line_colors (dict, optional): line color map with {feature name:rgb values}
         fill_colors (dict, optional): fill color map with {feature name:rgba values}
-        storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
         local_config (string): local config yaml file
 
     Returns:
@@ -707,9 +762,7 @@ def regional_polygon_cli(
 def regional_polygon(
     slide_manifest: DataFrame[SlideSchema],
     output_urlpath: str,
-    image_filename: str,
     annotation_name: str,
-    classes_to_include: List,
     line_colors: Optional[Dict[str, str]],
     fill_colors: Optional[Dict[str, str]],
     storage_options: Dict,
@@ -717,6 +770,23 @@ def regional_polygon(
     annotation_column: str = "regional_geojson_url",
     output_column: str = "regional_dsa_url",
 ):
+    """Build DSA annotation json from regional annotation geojson
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest
+        output_urlpath (string): URL/path prefix for saving dsa annotation json
+        annotation_name (string): name of the annotation to be displayed in DSA
+        line_colors (dict, optional): line color map with {feature name:rgb values}
+        fill_colors (dict, optional): fill color map with {feature name:rgba values}
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        annotation_column (string): column containing url to regional geojson
+        output_column_suffix (string): column suffix with result url to add to slide_manifest
+
+    Returns:
+        DataFrame[SlideSchema]: slide schema
+    """
+
     if annotation_column not in slide_manifest.columns:
         raise ValueError(f"{annotation_column} not found in slide manifest")
     client = get_or_create_dask_client()
@@ -812,6 +882,7 @@ def qupath_polygon_cli(
     line_colors: Optional[dict[str, str]] = None,
     fill_colors: Optional[dict[str, str]] = None,
     storage_options: dict = {},
+    output_storage_options: dict = {},
     local_config: str = "",
 ):
     """Build DSA annotation json from Qupath polygon geojson
@@ -826,8 +897,8 @@ def qupath_polygon_cli(
         e.g. ["Tumor", "Stroma", ...]
         line_colors (dict, optional): line color map with {feature name:rgb values}
         fill_colors (dict, optional): fill color map with {feature name:rgba values}
-        storage_options (dict): storage options to pass to read/write functions
-        output_storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
         local_config (string): local config yaml file
 
     Returns:
@@ -862,6 +933,26 @@ def qupath_polygon(
     annotation_column: str = "qupath_geojson_url",
     output_column: str = "qupath_dsa_url",
 ):
+    """Build DSA annotation json from Qupath polygon geojson
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        output_urlpath (string): URL/path prefix for saving the DSA compatible annotation
+        json
+        image_filename (string): name of the image file in DSA e.g. 123.svs
+        annotation_name (string): name of the annotation to be displayed in DSA
+        classes_to_include (list): list of classification labels to visualize
+        e.g. ["Tumor", "Stroma", ...]
+        line_colors (dict, optional): line color map with {feature name:rgb values}
+        fill_colors (dict, optional): fill color map with {feature name:rgba values}
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        annotation_column (string): column containing url to qupath geojson
+        output_column_suffix (string): column suffix with result url to add to slide_manifest
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
     if annotation_column not in slide_manifest.columns:
         raise ValueError(f"{annotation_column} not found in slide manifest")
     client = get_or_create_dask_client()
@@ -987,14 +1078,16 @@ def bitmask_polygon_cli(
 
     Args:
         input_map (map): map of {label:path_to_bitmask_png}
-        output_dir (string): directory to save the DSA compatible annotation
+        output_urlpath (string): url/path to save the DSA compatible annotation
         json
         image_filename (string): name of the image file in DSA e.g. 123.svs
         annotation_name (string): name of the annotation to be displayed in DSA
         line_colors (dict, optional): line color map with {feature name:rgb values}
         fill_colors (dict, optional): fill color map with {feature name:rgba values}
         scale_factor (int, optional): scale to match the image on DSA.
-        storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        local_config (string): local config yaml file
 
     Returns:
         dict: annotation file path
@@ -1144,6 +1237,28 @@ def heatmap(
     storage_options: Dict,
     output_storage_options: Dict,
 ):
+    """Generate heatmap based on the tile scores
+
+    Creates a heatmap for the given column, using the color palette `viridis`
+    to set a fill value
+    - the color ranges from purple to yellow, for scores from 0 to 1.
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        output_urlpath (string): URL/path prefix to save the DSA compatible annotation
+        json
+        annotation_name (string): name of the annotation to be displayed in DSA
+        column (string): column to visualize e.g. tile_score
+        tile_size (int): size of tiles
+        scale_factor (int, optional): scale to match the image on DSA.
+        line_colors (dict, optional): line color map with {feature name:rgb values}
+        fill_colors (dict, optional): fill color map with {feature name:rgba values}
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+
+    Returns:
+        dict: annotation file path. None if error in writing the file.
+    """
     if "tiles_url" not in slide_manifest.columns:
         raise ValueError("tiles_url not found in slide manifest")
     client = get_or_create_dask_client()
@@ -1199,9 +1314,10 @@ def __heatmap(
         column (list[string]): columns to visualize e.g. tile_score
         tile_size (int): size of tiles
         scale_factor (int, optional): scale to match the image on DSA.
-        line_colors (Optional[dict[str,str]]): line color map with {feature name:rgb values}
         fill_colors (Optional[dict[str,str]]): fill color map with {feature name:rgba values}
-        storage_options (dict): storage options to pass to read/write functions
+        line_colors (Optional[dict[str,str]]): line color map with {feature name:rgb values}
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
 
     Returns:
         dict: DSA annotation
@@ -1272,6 +1388,7 @@ def bmp_polygon_cli(
     fill_colors: Optional[Dict[str, str]] = None,
     scale_factor: Optional[int] = 1,
     storage_options: Dict = {},
+    output_storage_options: Dict = {},
     local_config: str = "",
 ):
     """Build DSA annotation json from a BMP with multiple labels.
@@ -1288,7 +1405,8 @@ def bmp_polygon_cli(
         line_colors (dict[str,str], optional): line color map with {feature name:rgb values}
         fill_colors (dict[str,str], optional): fill color map with {feature name:rgba values}
         scale_factor (int, optional): scale to match image DSA.
-        storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
 
     Returns:
         dict: annotation file path
@@ -1323,6 +1441,27 @@ def bmp_polygon(
     annotation_column: str = "bmp_polygon_url",
     output_column: str = "bmp_polygon_dsa_url",
 ):
+    """Build DSA annotation json from a BMP with multiple labels.
+
+    Vectorizes and simplifies contours per label.
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        output_urlpath (string): url/path prefix to save the DSA compatible annotation
+        json
+        label_map (dict[int,str]): map of label number to label name
+        annotation_name (string): name of the annotation to be displayed in DSA
+        line_colors (dict[str,str], optional): line color map with {feature name:rgb values}
+        fill_colors (dict[str,str], optional): fill color map with {feature name:rgba values}
+        scale_factor (int, optional): scale to match image DSA.
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        annotation_column (string): column containing url to BMP polygon
+        output_column_suffix (string): column suffix with result url to add to slide_manifest
+
+    Returns:
+        dict: annotation file path
+    """
     if annotation_column not in slide_manifest.columns:
         raise ValueError(f"{annotation_column} not found in slide manifest")
     client = get_or_create_dask_client()
@@ -1374,7 +1513,8 @@ def __bmp_polygon(
         line_colors (dict[str,str], optional): line color map with {feature name:rgb values}
         fill_colors (dict[str,str], optional): fill color map with {feature name:rgba values}
         scale_factor (int, optional): scale to match image DSA.
-        storage_options (dict): storage options to pass to read/write functions
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
 
     Returns:
         dict: DSA annotation

--- a/src/luna/pathology/cli/extract_shape_features.py
+++ b/src/luna/pathology/cli/extract_shape_features.py
@@ -43,6 +43,10 @@ def cli(
         slide_mask_urlpath (str): URL/path to slide mask (*.tif)
         label_cols (List[str]): list of labels that coorespond to those in slide_mask_urlpath
         output_urlpath (str): output URL/path prefix
+        include_smaller_regions (bool): include the smaller regions (not just larget)
+        storage_options (dict): storage options to pass to read functions
+        output_storage_options (dict): storage options to pass to write functions
+        local_config (str): local config YAML file
 
     Returns:
         dict: output .tif path and the number of shapes for which features were generated

--- a/src/luna/pathology/cli/extract_tile_shape_features.py
+++ b/src/luna/pathology/cli/extract_tile_shape_features.py
@@ -135,7 +135,6 @@ def cli(
 
 def extract_tile_shape_features(
     slide_manifest: DataFrame[SlideSchema],
-    slide_urlpath: str,
     output_urlpath: str,
     resize_factor: int = 16,
     detection_probability_threshold: Optional[float] = None,
@@ -161,6 +160,27 @@ def extract_tile_shape_features(
         "solidity",
     ],
 ):
+    """Extracts shape and spatial features (HIF features) from a slide mask.
+
+     Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        output_urlpath (str): output URL/path
+        resize_factor (int): factor to downsample slide image
+        detection_probability_threshold (Optional[float]): detection probability threshold
+        statistical_descriptors (str): statistical descriptors to calculate. One of All, Quantiles, Stats, or Density
+        cellular_features (str): cellular features to include. One of All, Nucleus, Cell, Cytoplasm, and Membrane
+        property_type (str): properties to include. One of All, Geometric, or Stain
+        include_smaller_regions (bool): include smaller regions in output
+        label_cols (List[str]): list of score columns to use for the classification. Tile is classified as the column with the max score
+        storage_options (dict): storage options to pass to reading functions
+        output_storage_options (dict): storage options to pass to writing functions
+        local_config (str): local config yaml file
+        objects_column (str): slide manifest column name with stardist geoJSON URLs
+        properties (List[str]): properties to extract
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
     client = get_or_create_dask_client()
 
     futures = []
@@ -225,8 +245,10 @@ def __extract_tile_shape_features(
     """Extracts shape and spatial features (HIF features) from a slide mask.
 
      Args:
-        objects (Union[str, gpd.GeoDataFrame]): URL/path to slide (tiffslide supported formats)
-        tiles (Union[str, pd.DataFrame]): URL/path to object file (geopandas supported formats)
+        objects_urlpath (str): URL/path to object file (geopandas supported formats)
+        tiles_urlpath (str): URL/path to tiles manifest (parquet)
+        slide_urlpath (str): URL/path to slide (tiffslide supported formats)
+        output_urlpath (str): output URL/path
         resize_factor (int): factor to downsample slide image
         detection_probability_threshold (Optional[float]): detection
             probability threshold
@@ -234,7 +256,10 @@ def __extract_tile_shape_features(
         statistical_descriptors (StatisticalDescriptors): statistical descriptors to calculate
         cellular_features (CellularFeatures): cellular features to include
         property_type (PropertyType): properties to include
+        include_smaller_regions (bool): include smaller regions
         label_cols (List[str]): list of score columns to use for the classification. Tile is classified as the column with the max score
+        storage_options (dict): storage options to pass to reading functions
+        output_storage_options (dict): storage options to pass to writing functions
         properties (List[str]): list of whole slide image properties to
             extract. Needs to be parquet compatible (numeric).
     Returns:

--- a/src/luna/pathology/cli/merge_shape_features.py
+++ b/src/luna/pathology/cli/merge_shape_features.py
@@ -1,20 +1,20 @@
-import fire
-import glob
-from typing import List, Union
-import pandas as pd
 from pathlib import Path
-import fsspec
-from fsspec import open
+from typing import List, Union
 
-from luna.common.utils import get_config, timed, save_metadata
-from luna.common.models import ShapeFeaturesSchema
+import fire
+import fsspec
+import pandas as pd
+
+from luna.common.utils import get_config, save_metadata, timed
 
 
 @timed
 @save_metadata
 def cli(
-    shape_features_urlpaths: Union[str,List[str]] = "???",
+    shape_features_urlpaths: Union[str, List[str]] = "???",
     output_urlpath: str = ".",
+    flatten_index: bool = True,
+    fraction_not_null: float = 0.5,
     storage_options: dict = {},
     output_storage_options: dict = {},
     local_config: str = "",
@@ -24,6 +24,7 @@ def cli(
     Args:
         shape_features_urlpaths (List[str]): URL/paths to shape featurs parquet files
         output_urlpath (str): URL/path to output parquet file
+        fraction_not_null (float): fraction not null to keep column to keep in wide format
         storage_options (dict): storage options to pass to reading functions
         output_storage_options (dict): storage options to pass to writing functions
         local_config (str): local config yaml file
@@ -35,36 +36,49 @@ def cli(
 
     dfs = []  # type: list[str]
     if type(config["shape_features_urlpaths"]) == list:
-        for urlpath in config['shape_features_urlpaths']:
-            fs, path = fsspec.core.url_to_fs(urlpath, **config['storage_options'])
-            with fs.open(path, 'rb') as of:
+        for urlpath in config["shape_features_urlpaths"]:
+            fs, path = fsspec.core.url_to_fs(urlpath, **config["storage_options"])
+            with fs.open(path, "rb") as of:
                 df = pd.read_parquet(of)
-            ShapeFeaturesSchema.validate(df)
             dfs.append(df)
     else:
-        fs, path_prefix = fsspec.core.url_to_fs(config['shape_features_urlpaths'],
-                                                **config['storage_options'])
+        fs, path_prefix = fsspec.core.url_to_fs(
+            config["shape_features_urlpaths"], **config["storage_options"]
+        )
         for path in fs.glob(f"{path_prefix}/**/shape_features.parquet"):
-            with fs.open(path, 'rb') as of:
+            with fs.open(path, "rb") as of:
                 df = pd.read_parquet(of)
-            ShapeFeaturesSchema.validate(df)
             dfs.append(df)
 
     df = pd.concat(dfs)
-    fs, path_prefix = fsspec.core.url_to_fs(config['output_urlpath'],
-                                            **config['output_storage_options'])
-    path = Path(path_prefix) / 'long_shape_features.parquet'
+    fs, path_prefix = fsspec.core.url_to_fs(
+        config["output_urlpath"], **config["output_storage_options"]
+    )
+    path = Path(path_prefix) / "long_shape_features.parquet"
 
-    with fs.open(path, 'wb', **config["output_storage_options"]) as of:
+    with fs.open(path, "wb", **config["output_storage_options"]) as of:
         df.to_parquet(of)
 
-    df.variable = df.variable.str.replace('µ','u').replace(r'(: |:)', ' ', regex=True).replace('[^a-zA-Z0-9 \n]', '', regex=True)
-    wide_path = Path(path_prefix) / 'wide_shape_features.parquet'
-    wide_df = df.pivot(index="slide_id", columns=["Parent", "Class", "variable"], values="value")
-    with fs.open(wide_path, 'wb', **config["output_storage_options"]) as of:
+    df.variable = (
+        df.variable.str.replace("µ", "u")
+        .replace(r"(: |:)", " ", regex=True)
+        .replace("[^a-zA-Z0-9 \n]", "", regex=True)
+    )
+    wide_path = Path(path_prefix) / "wide_shape_features.parquet"
+    wide_df = df.pivot(
+        index="slide_id", columns=["Parent", "Class", "variable"], values="value"
+    )
+    wide_df = wide_df.loc[
+        :, wide_df.isna().sum() < len(wide_df) * config["fraction_not_null"]
+    ]
+    if config["flatten_index"]:
+        wide_df.columns = ["_".join(col).strip() for col in wide_df.columns.values]
+        wide_df.columns = wide_df.columns.str.replace(" ", "_")
+
+    with fs.open(wide_path, "wb", **config["output_storage_options"]) as of:
         wide_df.to_parquet(of)
 
-    return  {
+    return {
         "long_shape_features": fs.unstrip_protocol(str(path)),
         "wide_shape_features": fs.unstrip_protocol(str(wide_path)),
         "num_features": len(wide_df.columns),
@@ -74,7 +88,6 @@ def cli(
 def fire_cli():
     fire.Fire(cli)
 
+
 if __name__ == "__main__":
     fire_cli()
-
-

--- a/src/luna/pathology/cli/run_stardist_cell_detection.py
+++ b/src/luna/pathology/cli/run_stardist_cell_detection.py
@@ -46,7 +46,7 @@ def stardist_simple_cli(
         local_config (str): local config yaml file
 
     Returns:
-        pd.DataFrame: metadata about function call
+        dict: metadata about function call
     """
 
     config = get_config(vars())
@@ -79,7 +79,29 @@ def stardist_simple(
     storage_options: dict,
     output_storage_options: dict,
     annotation_column: str = "stardist_geojson_url",
-) -> pd.DataFrame:
+) -> DataFrame[SlideSchema]:
+    """Run stardist using qupath CLI on slides in a slide manifest from
+    slide_etl. URIs to resulting GeoJSON will be stored in a specified column
+    of the returned slide manifest.
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        cell_expansion_size (float): size in pixels to expand cell cytoplasm
+        image_type (str): qupath image type (BRIGHTFIELD_H_DAB)
+        output_urlpath (str): output url/path
+        debug_opts (str): debug options passed as arguments to groovy script
+        num_cores (int): Number of cores to use for CPU parallelization
+        image (str): docker/singularity image
+        use_singularity (bool): use singularity instead of docker
+        max_heap_size (str): maximum heap size to pass to java options
+        storage_options (dict): storage options to pass to reading functions
+        output_storage_options (dict): storage options to pass to writing functions
+        annotation_column (str): name of column in resulting slide manifest to store GeoJson URIs
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
+
     client = get_or_create_dask_client()
 
     futures = []
@@ -122,8 +144,10 @@ def __stardist_simple(
     max_heap_size: str,
     storage_options: dict,
     output_storage_options: dict,
-) -> pd.DataFrame:
-    """Run stardist using qupath CLI
+) -> dict:
+    """Run stardist using qupath CLI on slides in a slide manifest from
+    slide_etl. URIs to resulting GeoJSON will be stored in a specified column
+    of the returned slide manifest.
 
     Args:
         slide_urlpath (str): path to slide image (virtual slide formats compatible with openslide, .svs, .tif, .scn, ...)
@@ -139,7 +163,7 @@ def __stardist_simple(
         output_storage_options (dict): storage options to pass to writing functions
 
     Returns:
-        pd.DataFrame: cell detections
+        dict: run metadata
     """
     fs, slide_path = fsspec.core.url_to_fs(slide_urlpath, **storage_options)
     ofs, output_path = fsspec.core.url_to_fs(output_urlpath, **output_storage_options)
@@ -228,7 +252,7 @@ def stardist_cell_lymphocyte_cli(
     max_heap_size: str = "64G",
     storage_options: dict = {},
     output_storage_options: dict = {},
-):
+) -> dict:
     """Run stardist using qupath CLI
 
     Args:
@@ -236,13 +260,14 @@ def stardist_cell_lymphocyte_cli(
         output_urlpath (str): output url/path
         num_cores (int): Number of cores to use for CPU parallelization
         use_gpu (bool): use GPU
+        image (str): docker/singularity image
         use_singularity (bool): use singularity instead of docker
         max_heap_size (str): maximum heap size to pass to java options
         storage_options (dict): storage options to pass to reading functions
         output_storage_options (dict): storage options to pass to writing functions
 
     Returns:
-        pd.DataFrame: cell detections
+        dict: run metadata
     """
     config = get_config(vars())
     slide_id = Path(config["slide_urlpath"]).stem
@@ -272,7 +297,24 @@ def stardist_cell_lymphocyte(
     storage_options: dict = {},
     output_storage_options: dict = {},
     annotation_column: str = "lymphocyte_geojson_url",
-):
+) -> DataFrame[SlideSchema]:
+    """Run stardist using qupath CLI
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        output_urlpath (str): output url/path
+        num_cores (int): Number of cores to use for CPU parallelization
+        use_gpu (bool): use GPU
+        image (str): docker/singularity image
+        use_singularity (bool): use singularity instead of docker
+        max_heap_size (str): maximum heap size to pass to java options
+        storage_options (dict): storage options to pass to reading functions
+        output_storage_options (dict): storage options to pass to writing functions
+        annotation_column (str): name of column in resulting slide manifest to store GeoJson URIs
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
     client = get_or_create_dask_client()
 
     futures = []
@@ -313,7 +355,7 @@ def __stardist_cell_lymphocyte(
     max_heap_size: str = "64G",
     storage_options: dict = {},
     output_storage_options: dict = {},
-) -> pd.DataFrame:
+) -> dict:
     """Run stardist using qupath CLI
 
     Args:
@@ -321,12 +363,13 @@ def __stardist_cell_lymphocyte(
         output_urlpath (str): output url/path
         num_cores (int): Number of cores to use for CPU parallelization
         use_gpu (bool): use GPU
+        image (str): docker/singularity image
         use_singularity (bool): use singularity instead of docker
         max_heap_size (str): maximum heap size to pass to java options
         storage_options (dict): storage options to pass to reading functions
 
     Returns:
-        pd.DataFrame: cell detections
+        dict: run metadata
     """
     fs, slide_path = fsspec.core.url_to_fs(slide_urlpath, **storage_options)
     ofs, output_path = fsspec.core.url_to_fs(output_urlpath, **output_storage_options)

--- a/src/luna/pathology/cli/run_stardist_cell_detection.py
+++ b/src/luna/pathology/cli/run_stardist_cell_detection.py
@@ -5,14 +5,17 @@ import fire
 import fsspec
 import pandas as pd
 from loguru import logger
+from pandera.typing import DataFrame
 
+from luna.common.dask import get_or_create_dask_client
+from luna.common.models import SlideSchema
 from luna.common.runners import runner_provider
 from luna.common.utils import get_config, local_cache_urlpath, save_metadata, timed
 
 
 @timed
 @save_metadata
-def stardist_simple(
+def stardist_simple_cli(
     slide_urlpath: str = "???",
     cell_expansion_size: float = "???",  # type: ignore
     image_type: str = "???",
@@ -47,16 +50,8 @@ def stardist_simple(
     """
 
     config = get_config(vars())
-    fs, output_path = fsspec.core.url_to_fs(
-        config["output_urlpath"], **config["output_storage_options"]
-    )
-    slide_id = Path(config["slide_urlpath"]).stem
-    output_header_file = Path(output_path) / f"{slide_id}_cell_objects.parquet"
-    if fs.exists(output_header_file):
-        logger.info(f"outputs already exist: {config['output_urlpath']}")
-        return
 
-    df = stardist_simple_main(
+    return __stardist_simple(
         config["slide_urlpath"],
         config["cell_expansion_size"],
         config["image_type"],
@@ -65,36 +60,57 @@ def stardist_simple(
         config["num_cores"],
         config["image"],
         config["use_singularity"],
-        config['max_heap_size'],
+        config["max_heap_size"],
         config["storage_options"],
         config["output_storage_options"],
     )
 
-    with fs.open(output_header_file, "wb") as of:
-        df.to_parquet(of)
 
-    logger.info("generated cell data:")
-    logger.info(df)
+def stardist_simple(
+    slide_manifest: DataFrame[SlideSchema],
+    cell_expansion_size: float,
+    image_type: str,
+    output_urlpath: str,
+    debug_opts: str,
+    num_cores: int,
+    image: str,
+    use_singularity: bool,
+    max_heap_size: str,
+    storage_options: dict,
+    output_storage_options: dict,
+    annotation_column: str = "stardist_geojson_url",
+) -> pd.DataFrame:
+    client = get_or_create_dask_client()
 
-    output_geojson_file = Path(output_path) / "cell_detections.geojson"
+    futures = []
+    for row in slide_manifest.itertuples(name="Slide"):
+        future = client.submit(
+            __stardist_simple,
+            row.url,
+            cell_expansion_size,
+            image_type,
+            output_urlpath,
+            debug_opts,
+            num_cores,
+            image,
+            use_singularity,
+            max_heap_size,
+            storage_options,
+            output_storage_options,
+        )
+        futures.append(future)
+    results = client.gather(futures)
+    for idx, result in enumerate(results):
+        slide_manifest.at[idx, annotation_column] = results["geojson_url"]
 
-    properties = {
-        "cell_objects": str(output_header_file),
-        "feature_data": str(output_header_file),
-        "geojson_features": str(output_geojson_file),
-        "spatial": True,
-        "total_cells": len(df),
-        "segment_keys": {"slide_id": slide_id},
-    }
-
-    return properties
+    return slide_manifest
 
 
 @local_cache_urlpath(
     file_key_write_mode={"slide_urlpath": "r"},
     dir_key_write_mode={"output_urlpath": "w"},
 )
-def stardist_simple_main(
+def __stardist_simple(
     slide_urlpath: str,
     cell_expansion_size: float,
     image_type: str,
@@ -128,7 +144,13 @@ def stardist_simple_main(
     fs, slide_path = fsspec.core.url_to_fs(slide_urlpath, **storage_options)
     ofs, output_path = fsspec.core.url_to_fs(output_urlpath, **output_storage_options)
 
-    if ofs.protocol == 'file' and not ofs.exists(output_path):
+    slide_id = Path(slide_urlpath).stem
+    output_header_file = Path(output_path) / f"{slide_id}_cell_objects.parquet"
+    if ofs.exists(output_header_file):
+        logger.info(f"outputs already exist: {output_header_file}")
+        return
+
+    if ofs.protocol == "file" and not ofs.exists(output_path):
         ofs.mkdir(output_path)
 
     runner_type = "DOCKER"
@@ -159,8 +181,11 @@ def stardist_simple_main(
     }
     runner = runner_provider.get(runner_type, **runner_config)
     executor = runner.run()
-    for line in executor:
-        print(line)
+    try:
+        for line in executor:
+            logger.info(line)
+    except TypeError:
+        print(executor, "is not iterable")
 
     stardist_output = Path(output_path) / "cell_detections.tsv"
 
@@ -172,12 +197,28 @@ def stardist_simple_main(
         columns={"Centroid X µm": "x_coord", "Centroid Y µm": "y_coord"}
     )  # x,ys follow this convention
 
-    return df
+    with ofs.open(output_header_file, "wb") as of:
+        df.to_parquet(of)
+
+    logger.info("generated cell data:")
+    logger.info(df)
+
+    output_geojson_file = Path(output_path) / "cell_detections.geojson"
+
+    properties = {
+        "geojson_url": ofs.unstrip_protocol(str(output_geojson_file)),
+        "tsv_url": ofs.unstrip_protocol(str(stardist_output)),
+        "parquet_url": ofs.unstrip_protocol(str(output_header_file)),
+        "spatial": True,
+        "total_cells": len(df),
+    }
+
+    return properties
 
 
 @timed
 @save_metadata
-def stardist_cell_lymphocyte(
+def stardist_cell_lymphocyte_cli(
     slide_urlpath: str = "???",
     output_urlpath: str = ".",
     num_cores: int = 1,
@@ -204,19 +245,11 @@ def stardist_cell_lymphocyte(
         pd.DataFrame: cell detections
     """
     config = get_config(vars())
-
-    fs, output_path = fsspec.core.url_to_fs(
-        config["output_urlpath"], **config["output_storage_options"]
-    )
     slide_id = Path(config["slide_urlpath"]).stem
-    output_header_file = Path(output_path) / f"{slide_id}_cell_objects.parquet"
-    if fs.exists(output_header_file):
-        logger.info(f"outputs already exist: {config['output_urlpath']}")
-        return
-
-    df = stardist_cell_lymphocyte_main(
+    properties = __stardist_cell_lymphocyte(
         config["slide_urlpath"],
         config["output_urlpath"],
+        slide_id,
         config["num_cores"],
         config["use_gpu"],
         config["image"],
@@ -225,34 +258,54 @@ def stardist_cell_lymphocyte(
         config["storage_options"],
         config["output_storage_options"],
     )
-
-    with fs.open(output_header_file, "wb") as of:
-        df.to_parquet(of)
-
-    logger.info("generated cell data:")
-    logger.info(df)
-
-    output_geojson_file = Path(output_path) / "cell_detections.geojson"
-
-    properties = {
-        "cell_objects": str(output_header_file),
-        "feature_data": str(output_header_file),
-        "geojson_features": str(output_geojson_file),
-        "spatial": True,
-        "total_cells": len(df),
-        "segment_keys": {"slide_id": slide_id},
-    }
-
     return properties
+
+
+def stardist_cell_lymphocyte(
+    slide_manifest: DataFrame[SlideSchema],
+    output_urlpath: str,
+    num_cores: int,
+    use_gpu: bool = False,
+    image: str = "mskmind/qupath-stardist:0.4.3",
+    use_singularity: bool = False,
+    max_heap_size: str = "64G",
+    storage_options: dict = {},
+    output_storage_options: dict = {},
+    annotation_column: str = "lymphocyte_geojson_url",
+):
+    client = get_or_create_dask_client()
+
+    futures = []
+    for row in slide_manifest.itertuples(name="Slide"):
+        future = client.submit(
+            __stardist_cell_lymphocyte,
+            row.url,
+            output_urlpath,
+            row.id,
+            num_cores,
+            use_gpu,
+            image,
+            use_singularity,
+            max_heap_size,
+            storage_options,
+            output_storage_options,
+        )
+        futures.append(future)
+    results = client.gather(futures)
+    for idx, result in enumerate(results):
+        slide_manifest.at[idx, annotation_column] = result["geojson_url"]
+
+    return slide_manifest
 
 
 @local_cache_urlpath(
     file_key_write_mode={"slide_urlpath": "r"},
     dir_key_write_mode={"output_urlpath": "w"},
 )
-def stardist_cell_lymphocyte_main(
+def __stardist_cell_lymphocyte(
     slide_urlpath: str,
     output_urlpath: str,
+    slide_id: str,
     num_cores: int,
     use_gpu: bool = False,
     image: str = "mskmind/qupath-stardist:0.4.3",
@@ -276,10 +329,14 @@ def stardist_cell_lymphocyte_main(
         pd.DataFrame: cell detections
     """
     fs, slide_path = fsspec.core.url_to_fs(slide_urlpath, **storage_options)
-
     ofs, output_path = fsspec.core.url_to_fs(output_urlpath, **output_storage_options)
 
-    if ofs.protocol == 'file' and not ofs.exists(output_path):
+    output_header_file = Path(output_path) / f"{slide_id}_cell_objects.parquet"
+    if ofs.exists(output_header_file):
+        logger.info(f"outputs already exist: {output_header_file}")
+        return
+
+    if ofs.protocol == "file" and not ofs.exists(output_path):
         ofs.mkdir(output_path)
 
     qupath_cmd = "QuPath-cpu"
@@ -289,7 +346,6 @@ def stardist_cell_lymphocyte_main(
     runner_type = "DOCKER"
     if use_singularity:
         runner_type = "SINGULARITY"
-
 
     slide_filename = Path(slide_path).name
     command = f"{qupath_cmd} script --image /inputs/{slide_filename} /scripts/stardist_nuclei_and_lymphocytes.groovy"
@@ -316,8 +372,11 @@ def stardist_cell_lymphocyte_main(
     }
     runner = runner_provider.get(runner_type, **runner_config)
     executor = runner.run()
-    for line in executor:
-        print(line)
+    try:
+        for line in executor:
+            logger.info(line)
+    except TypeError:
+        print(executor, "is not iterable")
 
     stardist_output = Path(output_path) / "cell_detections.tsv"
 
@@ -329,14 +388,30 @@ def stardist_cell_lymphocyte_main(
         columns={"Centroid X µm": "x_coord", "Centroid Y µm": "y_coord"}
     )  # x,ys follow this convention
 
-    return df
+    with fs.open(output_header_file, "wb") as of:
+        df.to_parquet(of)
+
+    logger.info("generated cell data:")
+    logger.info(df)
+
+    output_geojson_file = Path(output_path) / "cell_detections.geojson"
+
+    properties = {
+        "geojson_url": ofs.unstrip_protocol(str(output_geojson_file)),
+        "tsv_url": ofs.unstrip_protocol(str(stardist_output)),
+        "parquet_url": ofs.unstrip_protocol(str(output_header_file)),
+        "spatial": True,
+        "total_cells": len(df),
+    }
+
+    return properties
 
 
 def fire_cli():
     fire.Fire(
         {
-            "simple": stardist_simple,
-            "cell-lymphocyte": stardist_cell_lymphocyte,
+            "simple": stardist_simple_cli,
+            "cell-lymphocyte": stardist_cell_lymphocyte_cli,
         }
     )
 

--- a/src/luna/pathology/cli/run_tissue_detection.py
+++ b/src/luna/pathology/cli/run_tissue_detection.py
@@ -1,17 +1,15 @@
 # General imports
 from functools import partial
 from pathlib import Path
-from typing import Optional, Union
-from urllib.parse import urlparse
+from typing import Dict, Optional
 
+import dask.bag as db
 import fire  # type: ignore
 import fsspec  # type: ignore
 import numpy as np
 import pandas as pd
 from dask.distributed import progress
-from fsspec import open  # type: ignore
 from loguru import logger
-from multimethod import multimethod
 from pandera.typing import DataFrame
 from PIL import Image, ImageEnhance
 from skimage.color import rgb2gray  # type: ignore
@@ -19,15 +17,15 @@ from skimage.filters import threshold_otsu  # type: ignore
 from tiffslide import TiffSlide
 
 from luna.common.dask import configure_dask_client, get_or_create_dask_client
-from luna.common.models import SlideSchema, Tile
+from luna.common.models import Tile
 from luna.common.utils import (
     get_config,
-    grouper,
     local_cache_urlpath,
+    make_temp_directory,
     save_metadata,
     timed,
 )
-from luna.pathology.cli.generate_tiles import generate_tiles
+from luna.pathology.cli.generate_tiles import __generate_tiles, generate_tiles
 from luna.pathology.common.utils import (
     get_array_from_tile,
     get_downscaled_thumbnail,
@@ -37,15 +35,16 @@ from luna.pathology.common.utils import (
 )
 
 
-def compute_otsu_score(tile: Tile, slide: TiffSlide, otsu_threshold: float) -> float:
+def compute_otsu_score(tile: Tile, slide_path: str, otsu_threshold: float) -> float:
     """
     Return otsu score for the tile.
     Args:
         row (pd.Series): row with tile metadata
-        slide_urlpath (str): path to slide
+        slide_path (str): path to slide
         otsu_threshold (float): otsu threshold value
     """
-    tile_arr = get_array_from_tile(tile, slide, 10)
+    with TiffSlide(slide_path) as slide:
+        tile_arr = get_array_from_tile(tile, slide, 10)
     score = np.mean((rgb2gray(tile_arr) < otsu_threshold).astype(int))
     return score
 
@@ -58,7 +57,7 @@ def get_purple_score(x):
 
 def compute_purple_score(
     tile: Tile,
-    slide: TiffSlide,
+    slide_path: str,
 ) -> float:
     """
     Return purple score for the tile.
@@ -66,13 +65,14 @@ def compute_purple_score(
         row (pd.Series): row with tile metadata
         slide_url (str): path to slide
     """
-    tile_arr = get_array_from_tile(tile, slide, 10)
+    with TiffSlide(slide_path) as slide:
+        tile_arr = get_array_from_tile(tile, slide, 10)
     return get_purple_score(tile_arr)
 
 
 def compute_stain_score(
     tile: Tile,
-    slide: TiffSlide,
+    slide_path: str,
     vectors,
     channel,
     stain_threshold: float,
@@ -86,7 +86,8 @@ def compute_stain_score(
         channel (int): stain channel
         stain_threshold (float): stain threshold value
     """
-    tile_arr = get_array_from_tile(tile, slide, 10)
+    with TiffSlide(slide_path) as slide:
+        tile_arr = get_array_from_tile(tile, slide, 10)
     stain = pull_stain_channel(tile_arr, vectors=vectors, channel=channel)
     score = np.mean(stain > stain_threshold)
     return score
@@ -115,7 +116,7 @@ def cli(
         filter_query (str): pandas query by which to filter tiles based on their various tissue detection scores
         tile_size (int): size of tiles to use (at the requested magnification)
         thumbnail_magnification (Optional[int]): Magnification scale at which to perform computation
-        output_urlpath (str): Output url/path prefix
+        output_urlpath (str): Output url/path
         dask_options (dict): dask options
         storage_options (dict): storage options to pass to reading functions
         output_storage_options (dict): storage options to pass to writing functions
@@ -131,165 +132,114 @@ def cli(
     if not config["tile_size"] and not config["tiles_urlpath"]:
         raise fire.core.FireError("Specify either tiles_urlpath or tile_size")
 
-    output_filesystem, output_urlpath_prefix = fsspec.core.url_to_fs(
-        config["output_urlpath"], **config["output_storage_options"]
-    )
+    slide_id = Path(config["slide_urlpath"]).stem
 
-    slide_id = Path(urlparse(config["slide_urlpath"]).path).stem
-    output_header_file = Path(output_urlpath_prefix) / f"{slide_id}.tiles.parquet"
+    tiles_urlpath = config["tiles_urlpath"]
 
-    df = detect_tissue(
-        config["slide_urlpath"],
-        config["tiles_urlpath"],
-        config["tile_size"],
-        config["thumbnail_magnification"],
-        config["tile_magnification"],
-        config["filter_query"],
-        config["batch_size"],
-        config["storage_options"],
-        config["output_urlpath"],
-        config["output_storage_options"],
-    )
-    with output_filesystem.open(output_header_file, "wb") as of:
-        logger.info(f"saving to {output_header_file}")
-        df.to_parquet(of)
-        properties = {
-            "tiles_manifest": output_header_file,
-            "total_tiles": len(df),
-        }
+    with make_temp_directory() as temp_dir:
+        if not tiles_urlpath:
+            result = __generate_tiles(
+                config["slide_urlpath"],
+                config["tile_size"],
+                temp_dir,
+                config["tile_magnification"],
+                config["storage_options"],
+            )
+            tiles_urlpath = result["tiles_url"]
+
+        properties = __detect_tissue(
+            config["slide_urlpath"],
+            tiles_urlpath,
+            slide_id,
+            config["thumbnail_magnification"],
+            config["filter_query"],
+            config["batch_size"],
+            config["output_urlpath"],
+            config["storage_options"],
+            config["output_storage_options"],
+        )
 
     return properties
 
 
-@multimethod
 def detect_tissue(
     slide_manifest: DataFrame,
-    tile_size: int,
-    thumbnail_magnification: Optional[int] = None,
-    tile_magnification: Optional[int] = None,
-    filter_query: str = "",
-    batch_size: int = 2000,
-    storage_options: dict = {},
-    output_urlpath_prefix: str = "",
-    output_storage_options: dict = {},
-):
-    slide_manifest = SlideSchema(slide_manifest)
-    dfs = []
-    for row in slide_manifest.itertuples():
-        df = detect_tissue(
-            row.url,
-            tile_size,
-            thumbnail_magnification,
-            tile_magnification,
-            filter_query,
-            batch_size,
-            storage_options,
-            output_urlpath_prefix,
-            output_storage_options,
-        )
-        df["id"] = row.id
-        dfs.append(df)
-    tiles = pd.concat(dfs)
-    return tiles.merge(slide_manifest, on="id")
-
-
-# this doesn't work:
-#    client = get_client()
-#    futures = {
-#            row.id: client.submit(detect_tissue,
-#                                  row.url,
-#                                  tile_size,
-#                                  thumbnail_magnification,
-#                                  filter_query,
-#                                  storage_options,
-#                                  output_urlpath_prefix,
-#                                  output_storage_options,
-#                                  ) for row in slide_manifest.itertuples()
-#            }
-#    progress(futures)
-#    results = client.gather(futures)
-#    for k, v in results.items():
-#        v['id'] = str(k)
-#    tiles = pd.concat(results)
-#    return tiles.merge(slide_manifest, on='id')
-
-
-@multimethod
-def detect_tissue(
-    slide_urlpaths: Union[str, list[str]],
-    tile_size: int,
-    thumbnail_magnification: Optional[int] = None,
-    tile_magnification: Optional[int] = None,
-    filter_query: str = "",
-    batch_size: int = 2000,
-    storage_options: dict = {},
-    output_urlpath_prefix: str = "",
-    output_storage_options: dict = {},
-) -> pd.DataFrame:
-    if type(slide_urlpaths) == str:
-        slide_urlpaths = [slide_urlpaths]
-    dfs = []
-    for slide_urlpath in slide_urlpaths:
-        df = detect_tissue(
-            slide_urlpath,
-            "",
-            tile_size,
-            thumbnail_magnification,
-            tile_magnification,
-            filter_query,
-            batch_size,
-            storage_options,
-            output_urlpath_prefix,
-            output_storage_options,
-        )
-        o = urlparse(slide_urlpath)
-        df["id"] = Path(o.path).stem
-        dfs.append(df)
-    return pd.concat(dfs)
-
-
-@multimethod
-@local_cache_urlpath(
-    file_key_write_mode={
-        "slide_urlpath": "r",
-    },
-)
-def detect_tissue(
-    slide_urlpath: str,
-    tiles_urlpath: str = "",
     tile_size: Optional[int] = None,
     thumbnail_magnification: Optional[int] = None,
     tile_magnification: Optional[int] = None,
     filter_query: str = "",
     batch_size: int = 2000,
     storage_options: dict = {},
-    output_urlpath_prefix: str = "",
+    output_urlpath: str = ".",
     output_storage_options: dict = {},
 ) -> pd.DataFrame:
-    """Run simple/deterministic tissue detection algorithms based on a filter query, to reduce tiles to those (likely) to contain actual tissue
-    Args:
-        slide_urlpath (str): slide url/path
-        tile_size (int): size of tiles to use (at the requested magnification)
-        thumbnail_magnification (Optional[int]): Magnification scale at which to perform computation
-        filter_query (str): pandas query by which to filter tiles based on their various tissue detection scores
-        storage_options (dict): storage options to pass to reading functions
-        output_urlpath_prefix (str): output url/path prefix
-        output_storage_options (dict): output storage optoins
-    Returns:
-        pd.DataFrame
-    """
-
     client = get_or_create_dask_client()
 
-    if tiles_urlpath:
-        with open(tiles_urlpath, **storage_options) as of:
-            tiles_df = pd.read_parquet(of)
-    elif type(tile_size) == int:
-        tiles_df = generate_tiles(
-            slide_urlpath, tile_size, storage_options, tile_magnification
+    with make_temp_directory() as temp_dir:
+        if "tiles_url" not in slide_manifest.columns:
+            slide_manifest = generate_tiles(
+                slide_manifest,
+                tile_size,
+                temp_dir,
+                tile_magnification,
+                storage_options,
+            )
+
+        futures = []
+        for slide in slide_manifest.itertuples(name="Slide"):
+            future = client.submit(
+                __detect_tissue,
+                slide.url,
+                slide.tiles_url,
+                slide.id,
+                thumbnail_magnification,
+                filter_query,
+                batch_size,
+                output_urlpath,
+                storage_options,
+                output_storage_options,
+            )
+            futures.append(future)
+        progress(futures)
+
+        results = client.gather(futures)
+
+        for idx, result in enumerate(results):
+            slide_manifest.at[idx, "tiles_url"] = result["tiles_url"]
+
+    return slide_manifest
+
+
+@local_cache_urlpath(
+    file_key_write_mode={
+        "slide_urlpath": "r",
+    }
+)
+def __detect_tissue(
+    slide_urlpath: str,
+    tiles_urlpath: str,
+    slide_id: str,
+    thumbnail_magnification: Optional[int] = None,
+    filter_query: str = "",
+    batch_size: int = 2000,
+    output_urlpath: str = ".",
+    storage_options: dict = {},
+    output_storage_options: dict = {},
+) -> Dict:
+    output_filesystem, output_path = fsspec.core.url_to_fs(
+        output_urlpath, **output_storage_options
+    )
+
+    tiles_output_path = str(Path(output_path) / f"{slide_id}.tiles.parquet")
+    if output_filesystem.exists(tiles_output_path):
+        logger.info(
+            "Outputs already exist: {output_filesystem.unstrip_protocol(tiles_output_path)}"
         )
-    else:
-        raise RuntimeError("Specify tile_size or tile_urlpath")
+        return
+
+    tiles_df = pd.read_parquet(tiles_urlpath, storage_options=storage_options)
+
+    get_or_create_dask_client()
 
     with TiffSlide(slide_urlpath) as slide:
         logger.info(f"Slide dimensions {slide.dimensions}")
@@ -311,63 +261,52 @@ def detect_tissue(
         sample_arr = get_downscaled_thumbnail(slide, to_mag_scale_factor)
         logger.info(f"Sample array size: {sample_arr.shape}")
 
-    if output_urlpath_prefix:
-        with open(
-            output_urlpath_prefix + "/sample_arr.png", "wb", **output_storage_options
-        ) as f:
-            Image.fromarray(sample_arr).save(f, format="png")
+    with output_filesystem.open(Path(output_path) / "sample_arr.png", "wb") as f:
+        Image.fromarray(sample_arr).save(f, format="png")
 
     logger.info("Enhancing image...")
     enhanced_sample_img = ImageEnhance.Contrast(
         ImageEnhance.Color(Image.fromarray(sample_arr)).enhance(10)
     ).enhance(10)
-    if output_urlpath_prefix:
-        with open(
-            output_urlpath_prefix + "/enhanced_sample_arr.png",
-            "wb",
-            **output_storage_options,
-        ) as f:
-            enhanced_sample_img.save(f, format="png")
+    with output_filesystem.open(
+        Path(output_path) / "enhanced_sample_arr.png",
+        "wb",
+    ) as f:
+        enhanced_sample_img.save(f, format="png")
 
     logger.info("HSV space conversion...")
     hsv_sample_arr = np.array(enhanced_sample_img.convert("HSV"))
-    if output_urlpath_prefix:
-        with open(
-            output_urlpath_prefix + "/hsv_sample_arr.png",
-            "wb",
-            **output_storage_options,
-        ) as f:
-            Image.fromarray(np.array(hsv_sample_arr)).save(f, "png")
+    with output_filesystem.open(
+        Path(output_path) / "hsv_sample_arr.png",
+        "wb",
+    ) as f:
+        Image.fromarray(np.array(hsv_sample_arr)).save(f, "png")
 
     logger.info("Calculating max saturation...")
     hsv_max_sample_arr = np.max(hsv_sample_arr[:, :, 1:3], axis=2)
-    if output_urlpath_prefix:
-        with open(
-            output_urlpath_prefix + "/hsv_max_sample_arr.png",
-            "wb",
-            **output_storage_options,
-        ) as f:
-            Image.fromarray(hsv_max_sample_arr).save(f, "png")
+    with output_filesystem.open(
+        Path(output_path) / "hsv_max_sample_arr.png",
+        "wb",
+    ) as f:
+        Image.fromarray(hsv_max_sample_arr).save(f, "png")
 
     logger.info("Calculate and filter shadow mask...")
     shadow_mask = np.where(np.max(hsv_sample_arr, axis=2) < 10, 255, 0).astype(np.uint8)
-    if output_urlpath_prefix:
-        with open(
-            output_urlpath_prefix + "/shadow_mask.png", "wb", **output_storage_options
-        ) as f:
-            Image.fromarray(shadow_mask).save(f, "png")
+    with output_filesystem.open(
+        Path(output_path) / "shadow_mask.png",
+        "wb",
+    ) as f:
+        Image.fromarray(shadow_mask).save(f, "png")
 
     logger.info("Filter out shadow/dust/etc...")
     sample_arr_filtered = np.where(
         np.expand_dims(shadow_mask, 2) == 0, sample_arr, np.full(sample_arr.shape, 255)
     ).astype(np.uint8)
-    if output_urlpath_prefix:
-        with open(
-            output_urlpath_prefix + "/sample_arr_filtered.png",
-            "wb",
-            **output_storage_options,
-        ) as f:
-            Image.fromarray(sample_arr_filtered).save(f, "png")
+    with output_filesystem.open(
+        Path(output_path) / "sample_arr_filtered.png",
+        "wb",
+    ) as f:
+        Image.fromarray(sample_arr_filtered).save(f, "png")
 
     logger.info("Calculating otsu threshold...")
     threshold = threshold_otsu(rgb2gray(sample_arr_filtered))
@@ -390,104 +329,101 @@ def detect_tissue(
     )
 
     # Get the otsu mask
-    if output_urlpath_prefix:
-        logger.info("Saving otsu mask")
-        otsu_mask = np.where(rgb2gray(sample_arr_filtered) < threshold, 255, 0).astype(
-            np.uint8
-        )
-        with open(
-            output_urlpath_prefix + "/otsu_mask.png", "wb", **output_storage_options
-        ) as f:
-            Image.fromarray(otsu_mask).save(f, "png")
+    logger.info("Saving otsu mask")
+    otsu_mask = np.where(rgb2gray(sample_arr_filtered) < threshold, 255, 0).astype(
+        np.uint8
+    )
+    with output_filesystem.open(Path(output_path) / "otsu_mask.png", "wb") as f:
+        Image.fromarray(otsu_mask).save(f, "png")
 
-    if output_urlpath_prefix:
-        logger.info("Saving stain thumbnail")
-        deconv_sample_arr = pull_stain_channel(
-            sample_arr_filtered, vectors=stain_vectors
-        )
-        with open(
-            output_urlpath_prefix + "/deconv_sample_arr.png",
-            "wb",
-            **output_storage_options,
-        ) as f:
-            Image.fromarray(deconv_sample_arr).save(f, "png")
+    logger.info("Saving stain thumbnail")
+    deconv_sample_arr = pull_stain_channel(sample_arr_filtered, vectors=stain_vectors)
+    with output_filesystem.open(
+        Path(output_path) / "deconv_sample_arr.png",
+        "wb",
+    ) as f:
+        Image.fromarray(deconv_sample_arr).save(f, "png")
 
-        logger.info("Saving stain masks")
-        stain0_mask = np.where(
-            deconv_sample_arr[..., 0] > threshold_stain0, 255, 0
-        ).astype(np.uint8)
-        stain1_mask = np.where(
-            deconv_sample_arr[..., 1] > threshold_stain1, 255, 0
-        ).astype(np.uint8)
-        with open(
-            output_urlpath_prefix + "/stain0_mask.png", "wb", **output_storage_options
-        ) as f:
-            Image.fromarray(stain0_mask).save(f, "png")
-        with open(
-            output_urlpath_prefix + "/stain1_mask.png", "wb", **output_storage_options
-        ) as f:
-            Image.fromarray(stain1_mask).save(f, "png")
+    logger.info("Saving stain masks")
+    stain0_mask = np.where(deconv_sample_arr[..., 0] > threshold_stain0, 255, 0).astype(
+        np.uint8
+    )
+    stain1_mask = np.where(deconv_sample_arr[..., 1] > threshold_stain1, 255, 0).astype(
+        np.uint8
+    )
+    with output_filesystem.open(
+        Path(output_path) / "stain0_mask.png",
+        "wb",
+    ) as f:
+        Image.fromarray(stain0_mask).save(f, "png")
+    with output_filesystem.open(
+        Path(output_path) / "stain1_mask.png",
+        "wb",
+    ) as f:
+        Image.fromarray(stain1_mask).save(f, "png")
 
     if filter_query:
 
-        def f_many(iterator, tile_fn):
-            with TiffSlide(slide_urlpath) as slide:
-                return [tile_fn(tile=x, slide=slide) for x in iterator]
+        def f_many(iterator, tile_fn, **kwargs):
+            return [tile_fn(tile=x, **kwargs) for x in iterator]
 
+        chunks = db.from_sequence(
+            tiles_df.itertuples(name="Tile"), partition_size=batch_size
+        )
+        results = {}
         if "otsu_score" in filter_query:
             logger.info(f"Starting otsu thresholding, threshold={threshold}")
 
-            chunks = grouper(tiles_df.itertuples(name="Tile"), batch_size)
-            otsu_tile_fn = partial(compute_otsu_score, otsu_threshold=threshold)
-
-            futures = client.map(partial(f_many, tile_fn=otsu_tile_fn), chunks)
-            progress(futures)
-            tiles_df["otsu_score"] = np.concatenate(client.gather(futures))
+            # chunks = grouper(tiles_df.itertuples(name="Tile"), batch_size)
+            results["otsu_score"] = chunks.map_partitions(
+                partial(f_many, tile_fn=compute_otsu_score),
+                slide_path=slide_urlpath,
+                otsu_threshold=threshold,
+            )
         if "purple_score" in filter_query:
             logger.info("Starting purple scoring")
-            chunks = grouper(tiles_df.itertuples(name="Tile"), batch_size)
-
-            futures = client.map(partial(f_many, tile_fn=compute_purple_score), chunks)
-            progress(futures)
-            tiles_df["purple_score"] = np.concatenate(client.gather(futures))
+            results["purple_score"] = chunks.map_partitions(
+                partial(f_many, tile_fn=compute_purple_score), slide_path=slide_urlpath
+            )
         if "stain0_score" in filter_query:
             logger.info(
                 f"Starting stain thresholding, channel=0, threshold={threshold_stain0}"
             )
-
-            chunks = grouper(tiles_df.itertuples(name="Tile"), batch_size)
-            stain_tile_fn = partial(
-                compute_stain_score,
+            results["stain0_score"] = chunks.map_partitions(
+                partial(f_many, tile_fn=compute_stain_score),
                 vectors=stain_vectors,
                 channel=0,
                 stain_threshold=threshold_stain0,
+                slide_path=slide_urlpath,
             )
-
-            futures = client.map(partial(f_many, tile_fn=stain_tile_fn), chunks)
-            progress(futures)
-            tiles_df["stain0_score"] = np.concatenate(client.gather(futures))
         if "stain1_score" in filter_query:
             logger.info(
                 f"Starting stain thresholding, channel=1, threshold={threshold_stain1}"
             )
-            chunks = grouper(tiles_df.itertuples(name="Tile"), batch_size)
-            stain_tile_fn = partial(
-                compute_stain_score,
+            results["stain1_score"] = chunks.map_partitions(
+                partial(f_many, tile_fn=compute_stain_score),
                 vectors=stain_vectors,
                 channel=1,
                 stain_threshold=threshold_stain1,
+                slide_path=slide_urlpath,
             )
 
-            futures = client.map(partial(f_many, tile_fn=stain_tile_fn), chunks)
-            progress(futures)
-            tiles_df["stain1_score"] = np.concatenate(client.gather(futures))
-
+        for k, v in results.items():
+            tiles_df[k] = v.compute()
         logger.info(f"Filtering based on query: {filter_query}")
         tiles_df = tiles_df.query(filter_query)
 
     logger.info(tiles_df)
 
-    return tiles_df
+    with output_filesystem.open(tiles_output_path, "wb") as of:
+        logger.info(f"saving to {tiles_output_path}")
+        tiles_df.to_parquet(of)
+
+    properties = {
+        "tiles_url": output_filesystem.unstrip_protocol(tiles_output_path),
+        "total_tiles": len(tiles_df),
+    }
+    return properties
 
 
 def fire_cli():

--- a/src/luna/pathology/cli/run_tissue_detection.py
+++ b/src/luna/pathology/cli/run_tissue_detection.py
@@ -146,6 +146,7 @@ def cli(
                 config["slide_urlpath"],
                 config["tile_size"],
                 temp_dir,
+                config["force"],
                 config["tile_magnification"],
                 config["storage_options"],
             )

--- a/src/luna/pathology/cli/save_tiles.py
+++ b/src/luna/pathology/cli/save_tiles.py
@@ -37,10 +37,11 @@ def cli(
     Args:
         slide_urlpath (str): url/path to slide image (virtual slide formats compatible with openslide, .svs, .tif, .scn, ...)
         tiles_urlpath (str): url/path to tile manifest (.parquet)
-        output_urlpath (str): output url/path prefix
         batch_size (int): size in batch dimension to chuck jobs
+        output_urlpath (str): output url/path prefix
         storage_options (dict): storage options to reading functions
         output_storage_options (dict): storage options to writing functions
+        dask_options (dict): dask options
         local_config (str): url/path to local config yaml file
 
     Returns:

--- a/src/luna/pathology/cli/save_tiles.py
+++ b/src/luna/pathology/cli/save_tiles.py
@@ -68,7 +68,22 @@ def save_tiles(
     batch_size: int = 2000,
     storage_options: dict = {},
     output_storage_options: dict = {},
-):
+) -> DataFrame[SlideSchema]:
+    """Saves tiles to disk
+
+    Tiles addresses and arrays are saved as key-value pairs in (tiles.h5),
+    and the corresponding manifest/header file (tiles.parquet) is also generated
+
+    Args:
+        slide_manifest (DataFrame[SlideSchema]): slide manifest from slide_etl
+        output_urlpath (str): output url/path prefix
+        batch_size (int): size in batch dimension to chuck jobs
+        storage_options (dict): storage options to reading functions
+        output_storage_options (dict): storage options to writing functions
+
+    Returns:
+        DataFrame[SlideSchema]: slide manifest
+    """
     client = get_or_create_dask_client()
 
     if "tiles_url" not in slide_manifest.columns:

--- a/src/luna/pathology/cli/save_tiles.py
+++ b/src/luna/pathology/cli/save_tiles.py
@@ -1,23 +1,19 @@
 # General imports
 from pathlib import Path
-from typing import Optional
 
+import dask.bag as db
 import fire
 import fsspec
-import pandas as pd
 import h5py
-from dask.distributed import Client, as_completed, progress
-from fsspec import open
+import pandas as pd
+from dask.diagnostics import ProgressBar
 from loguru import logger
 from pandera.typing import DataFrame
 from tiffslide import TiffSlide
 
-
-from luna.common.models import TileSchema
-from luna.common.dask import get_or_create_dask_client, configure_dask_client
-from luna.common.utils import get_config, grouper, local_cache_urlpath, save_metadata, timed
-from luna.pathology.cli.generate_tiles import generate_tiles
-from luna.pathology.cli.run_tissue_detection import detect_tissue
+from luna.common.dask import configure_dask_client, get_or_create_dask_client
+from luna.common.models import SlideSchema
+from luna.common.utils import get_config, local_cache_urlpath, save_metadata, timed
 from luna.pathology.common.utils import get_array_from_tile
 
 
@@ -25,7 +21,7 @@ from luna.pathology.common.utils import get_array_from_tile
 @save_metadata
 def cli(
     slide_urlpath: str = "???",
-    tiles_urlpath: str = "???",  
+    tiles_urlpath: str = "???",
     batch_size: int = 2000,
     output_urlpath: str = ".",
     storage_options: dict = {},
@@ -54,42 +50,97 @@ def cli(
 
     configure_dask_client(**config["dask_options"])
 
-    slide_id = Path(config["slide_urlpath"]).stem
-    fs, output_urlpath_prefix = fsspec.core.url_to_fs(
-        config["output_urlpath"], **config["output_storage_options"]
-    )
-    output_h5_path = str(Path(output_urlpath_prefix) / f"{slide_id}.tiles.h5")
-    output_h5_urlpath = fs.unstrip_protocol(output_h5_path)
-
-    output_header_path = str(Path(output_urlpath_prefix) / f"{slide_id}.tiles.parquet")
-    output_header_urlpath = fs.unstrip_protocol(output_h5_path)
-
-    if fs.exists(output_header_path) and fs.exists(output_h5_path):
-        logger.info(
-            f"outputs already exist: {output_h5_urlpath}, {output_header_urlpath}"
-        )
-        return
-
-    with open(config["tiles_urlpath"], **config['storage_options']) as of:
-        df = pd.read_parquet(of)
-
-    df = save_tiles(
-        df,
+    properties = _save_tiles(
+        config["tiles_urlpath"],
         config["slide_urlpath"],
-        output_h5_urlpath,
+        config["output_urlpath"],
         config["batch_size"],
         config["storage_options"],
         config["output_storage_options"],
     )
 
-    logger.info(df)
-    with fs.open(output_header_path, "wb") as of:
-        df.to_parquet(of)
+    return properties
+
+
+def save_tiles(
+    slide_manifest: DataFrame[SlideSchema],
+    output_urlpath: str,
+    batch_size: int = 2000,
+    storage_options: dict = {},
+    output_storage_options: dict = {},
+):
+    client = get_or_create_dask_client()
+
+    if "tiles_url" not in slide_manifest.columns:
+        raise ValueError("Generate tiles first")
+
+    output_filesystem, output_path_prefix = fsspec.core.url_to_fs(
+        output_urlpath, **output_storage_options
+    )
+
+    if not output_filesystem.exists(output_urlpath):
+        output_filesystem.mkdir(output_urlpath)
+
+    futures = []
+    for slide in slide_manifest.itertuples(name="Slide"):
+        future = client.submit(
+            _save_tiles,
+            slide.tiles_url,
+            slide.url,
+            output_urlpath,
+            batch_size,
+            storage_options,
+            output_storage_options,
+        )
+        futures.append(future)
+
+    results = client.gather(futures)
+    for idx, result in enumerate(results):
+        slide_manifest.at[idx, "tiles_url"] = result["tiles_url"]
+
+    return slide_manifest
+
+
+def _save_tiles(
+    tiles_urlpath: str,
+    slide_urlpath: str,
+    output_urlpath: str,
+    batch_size: int = 2000,
+    storage_options: dict = {},
+    output_storage_options: dict = {},
+):
+    slide_id = Path(slide_urlpath).stem
+    ofs, output_urlpath_prefix = fsspec.core.url_to_fs(
+        output_urlpath, **output_storage_options
+    )
+
+    output_h5_path = str(Path(output_urlpath_prefix) / f"{slide_id}.tiles.h5")
+    output_h5_url = ofs.unstrip_protocol(output_h5_path)
+
+    output_tiles_path = str(Path(output_urlpath_prefix) / f"{slide_id}.tiles.parquet")
+    output_tiles_url = ofs.unstrip_protocol(output_tiles_path)
+
+    if ofs.exists(output_tiles_path) and ofs.exists(output_h5_path):
+        logger.info(f"outputs already exist: {output_h5_url}, {output_tiles_url}")
+        return
+    tiles_df = __save_tiles(
+        tiles_urlpath,
+        slide_urlpath,
+        output_h5_path,
+        batch_size,
+        storage_options,
+        output_storage_options,
+    )
+
+    tiles_df["tile_store"] = output_h5_url
+    logger.info(tiles_df)
+    with ofs.open(output_tiles_path, "wb") as of:
+        tiles_df.to_parquet(of)
 
     properties = {
-        "slide_tiles": output_header_urlpath,  # "Tiles" are the metadata that describe them
-        "feature_data": output_header_urlpath,  # Tiles can act like feature data
-        "total_tiles": len(df),
+        "tiles_url": output_tiles_url,  # "Tiles" are the metadata that describe them
+        "feature_data": output_h5_url,  # Tiles can act like feature data
+        "total_tiles": len(tiles_df),
     }
 
     return properties
@@ -98,12 +149,13 @@ def cli(
 @local_cache_urlpath(
     file_key_write_mode={
         "slide_urlpath": "r",
+        "output_h5_path": "w",
     },
 )
-def save_tiles(
-    df: DataFrame[TileSchema],
+def __save_tiles(
+    tiles_urlpath: str,
     slide_urlpath: str,
-    output_urlpath: str,
+    output_h5_path: str,
     batch_size: int = 2000,
     storage_options: dict = {},
     output_storage_options: dict = {},
@@ -114,62 +166,36 @@ def save_tiles(
     and the corresponding manifest/header file (tiles.parquet) is also generated
 
     Args:
-        df (DataFrame[TileSchema]): tile manifest
+        tiles_urlpath (str): tile manifest
         slide_urlpath (str): url/path to slide image (virtual slide formats compatible with openslide, .svs, .tif, .scn, ...)
         output_urlpath (str): output url/path
         batch_size (int): size in batch dimension to chuck jobs
-        storage_options (dict): storage options to reading functions
         output_storage_options (dict): storage options to writing functions
 
     Returns:
         dict: metadata about function call
     """
-    logger.info(f"Now generating tiles with batch_size={batch_size}!")
-    df = _save_tiles(df, slide_urlpath, output_urlpath, batch_size, storage_options, output_storage_options)
-    df["tile_store"] = output_urlpath
-    return df
 
-@local_cache_urlpath(
-    file_key_write_mode={
-        "output_urlpath": "w",
-    },
-)
-def _save_tiles(
-    df,
-    slide_urlpath,
-    output_urlpath: str,
-    batch_size: int = 2000,
-    storage_options: dict = {},
-    output_storage_options: dict = {},
-):
-    """
-    save address:tile arrays key:value pair in hdf5
-    a separate function from save_tiles such that the tile_store in the tile df is the non-cached path
-    """
-    client = get_or_create_dask_client()
+    tiles_df = pd.read_parquet(tiles_urlpath, storage_options=storage_options)
+
+    get_or_create_dask_client()
+
     def f_many(iterator):
-        with open(slide_urlpath, **storage_options) as of:
-            slide = TiffSlide(of)
-            return [
-                (
-                    x.address,
-                    get_array_from_tile(x, slide),
-                )
-                for x in iterator
-            ]
+        with TiffSlide(slide_urlpath) as slide:
+            return [(x.address, get_array_from_tile(x, slide=slide)) for x in iterator]
 
-    chunks = grouper(df.itertuples(name="Tile"), batch_size)
+    chunks = db.from_sequence(
+        tiles_df.itertuples(name="Tile"), partition_size=batch_size
+    )
 
-    futures = client.map(f_many, chunks)
-    progress(futures)
+    ProgressBar().register()
+    results = chunks.map_partitions(f_many)
+    with h5py.File(output_h5_path, "w") as hfile:
+        for result in results.compute():
+            address, tile_arr = result
+            hfile.create_dataset(address, data=tile_arr)
 
-    with h5py.File(output_urlpath, "w") as hfile:
-        for future in as_completed(futures):
-            for result in future.result():
-                address, tile_arr = result
-                hfile.create_dataset(address, data=tile_arr)
-
-    return df
+    return tiles_df
 
 
 def fire_cli():

--- a/src/luna/pathology/cli/slide_etl.py
+++ b/src/luna/pathology/cli/slide_etl.py
@@ -13,7 +13,7 @@ from pandera.typing import DataFrame
 from tiffslide import TiffSlide
 
 from luna.common.dask import configure_dask_client, get_or_create_dask_client
-from luna.common.models import Slide
+from luna.common.models import Slide, SlideSchema
 from luna.common.utils import apply_csv_filter, get_config, timed
 from luna.pathology.common.utils import (
     get_downscaled_thumbnail,
@@ -249,7 +249,7 @@ def __slide_etl(
             output_urlpath,
         )
 
-    return pd.json_normalize(slide.__dict__)
+    return DataFrame[SlideSchema](pd.json_normalize(slide.__dict__))
 
 
 def fire_cli():

--- a/src/luna/pathology/cli/slide_etl.py
+++ b/src/luna/pathology/cli/slide_etl.py
@@ -42,12 +42,13 @@ def cli(
 
 
     Args:
-        slide_url (str): path to slide image
+        slide_urlpath (str): path to slide image
         project_name (str): project name underwhich the slides should reside
         comment (str): comment and description of dataset
         subset_csv_urlpath (str): url/path to subset csv
-        storage_options (dict): storage options to pass to reading functions
+        debug_limit (int): limit number of slides
         output_urlpath (str): url/path to output table
+        storage_options (dict): storage options to pass to reading functions
         output_storage_options (dict): storage options to pass to writing functions
         local_config (str): url/path to YAML config file
         no_copy (bool): determines whether we copy slides to output_urlpath
@@ -120,16 +121,17 @@ def slide_etl(
     """Ingest slides by adding them to a file or s3 based storage location and generating metadata about them
 
     Args:
-        slide_url (str): path to slide image
+        slide_urls (Union[str, List[str])): path to slide image(s)
         project_name (str): project name underwhich the slides should reside
         comment (str): comment and description of dataset
         storage_options (dict): storage options to pass to reading functions
         output_urlpath (str): url/path to output table
         output_storage_options (dict): storage options to pass to writing functions
+        no_copy (bool): do not copy slides to output path
 
 
     Returns:
-        df (DataFrame): dataframe containing the metadata of all the slides
+        DataFrame[SlideSchema]: dataframe containing the metadata of all the slides
     """
     if isinstance(slide_urls, str):
         slide_urls = [slide_urls]

--- a/src/luna/pathology/cli/slide_etl.py
+++ b/src/luna/pathology/cli/slide_etl.py
@@ -13,7 +13,7 @@ from pandera.typing import DataFrame
 from tiffslide import TiffSlide
 
 from luna.common.dask import configure_dask_client, get_or_create_dask_client
-from luna.common.models import Slide, SlideSchema
+from luna.common.models import Slide
 from luna.common.utils import apply_csv_filter, get_config, timed
 from luna.pathology.common.utils import (
     get_downscaled_thumbnail,
@@ -249,8 +249,7 @@ def __slide_etl(
             output_urlpath,
         )
 
-    df = DataFrame[SlideSchema](pd.json_normalize(slide.__dict__))
-    return df
+    return pd.json_normalize(slide.__dict__)
 
 
 def fire_cli():

--- a/tests/luna/pathology/cli/test_dsa_viz.py
+++ b/tests/luna/pathology/cli/test_dsa_viz.py
@@ -1,24 +1,14 @@
-import os
-from pathlib import Path
-
 import fire
 import pytest
 
 from luna.pathology.cli.dsa_viz import (  # bmp_polygon,
-    bitmask_polygon,
-    heatmap,
-    qupath_polygon,
-    regional_polygon,
-    stardist_cell,
-    stardist_polygon,
+    bitmask_polygon_cli,
+    heatmap_cli,
+    qupath_polygon_cli,
+    regional_polygon_cli,
+    stardist_cell_cli,
+    stardist_polygon_cli,
 )
-
-
-def verify_cleanup(output_file):
-    assert os.path.exists(output_file)
-    # cleanup
-    os.remove(output_file)
-    os.remove(str(Path(output_file).parent) + "/metadata.yml")
 
 
 def test_stardist_polygon_s3(s3fs_client):
@@ -28,7 +18,7 @@ def test_stardist_polygon_s3(s3fs_client):
         "s3://dsatest/test/",
     )
     fire.Fire(
-        stardist_polygon,
+        stardist_polygon_cli,
         [
             "--local_config",
             "tests/testdata/pathology/stardist_polygon_s3.yml",
@@ -44,57 +34,58 @@ def test_stardist_polygon_s3(s3fs_client):
     )
 
 
-def test_stardist_polygon():
+def test_stardist_polygon(tmp_path):
+    print(tmp_path)
     fire.Fire(
-        stardist_polygon,
+        stardist_polygon_cli,
         [
+            "--output_urlpath",
+            str(tmp_path),
             "--local_config",
             "tests/testdata/pathology/stardist_polygon.yml",
         ],
     )
 
     output_file = (
-        "tests/luna/pathology/cli/testouts"
-        "/StarDist_Segmentations_with_Lymphocyte_Classifications_123.json"
+        tmp_path / "StarDist_Segmentations_with_Lymphocyte_Classifications_123.json"
     )
-    verify_cleanup(output_file)
+    assert output_file.exists()
 
 
-def test_stardist_cell():
+def test_stardist_cell(tmp_path):
     fire.Fire(
-        stardist_cell,
+        stardist_cell_cli,
         [
+            "--output_urlpath",
+            str(tmp_path),
             "--local_config",
             "tests/testdata/pathology/stardist_cell.yml",
         ],
     )
 
-    output_file = (
-        "tests/luna/pathology/cli/testouts"
-        "/Points_of_Classsified_StarDist_Cells_123.json"
-    )
-    verify_cleanup(output_file)
+    output_file = tmp_path / "Points_of_Classsified_StarDist_Cells_123.json"
+    assert output_file.exists()
 
 
-def test_regional_polygon():
+def test_regional_polygon(tmp_path):
     fire.Fire(
-        regional_polygon,
+        regional_polygon_cli,
         [
+            "--output_urlpath",
+            str(tmp_path),
             "--local_config",
             "tests/testdata/pathology" "/regional_polygon.yml",
         ],
     )
 
-    output_file = (
-        "tests/luna/pathology/cli/testouts" "/Slideviewer_Regional_Annotations_123.json"
-    )
-    verify_cleanup(output_file)
+    output_file = tmp_path / "Slideviewer_Regional_Annotations_123.json"
+    assert output_file.exists()
 
 
 def test_bitmask_polygon_invalid():
     with pytest.raises(Exception):
         fire.Fire(
-            bitmask_polygon,
+            bitmask_polygon_cli,
             [
                 "--input_map",
                 '{"Tumor": "non/existing/path/to/png.png"}',
@@ -122,11 +113,13 @@ def test_bitmask_polygon():
 """
 
 
-def test_heatmap():
+def test_heatmap(tmp_path):
     fire.Fire(
-        heatmap,
+        heatmap_cli,
         [
             "tests/testdata/pathology/tile_scores.parquet",
+            "--output_urlpath",
+            str(tmp_path),
             "--column",
             "otsu_score",
             "--local_config",
@@ -134,21 +127,21 @@ def test_heatmap():
         ],
     )
 
-    output_file = "tests/luna/pathology/cli/testouts" "/otsu_score_test_123.json"
-    verify_cleanup(output_file)
+    output_file = tmp_path / "otsu_score_test_123.json"
+    assert output_file.exists()
 
 
-def test_qupath_polygon():
+def test_qupath_polygon(tmp_path):
     fire.Fire(
-        qupath_polygon,
+        qupath_polygon_cli,
         [
             "tests/testdata/pathology/region_annotation_results.geojson",
+            "--output_urlpath",
+            str(tmp_path),
             "--local_config",
             "tests/testdata/pathology" "/qupath_polygon.yml",
         ],
     )
 
-    output_file = (
-        "tests/luna/pathology/cli/testouts" "/Qupath_Pixel_Classifier_Polygons_123.json"
-    )
-    verify_cleanup(output_file)
+    output_file = tmp_path / "Qupath_Pixel_Classifier_Polygons_123.json"
+    assert output_file.exists()

--- a/tests/luna/pathology/cli/test_run_stardist_cell_detection.py
+++ b/tests/luna/pathology/cli/test_run_stardist_cell_detection.py
@@ -4,7 +4,7 @@ import os
 import fire
 
 import docker
-from luna.pathology.cli.run_stardist_cell_detection import stardist_simple
+from luna.pathology.cli.run_stardist_cell_detection import stardist_simple_cli
 
 tmppath = "tests/testdata/pathology/stardist_cell_detection"
 
@@ -45,7 +45,7 @@ def test_cli(monkeypatch):
     monkeypatch.setattr(docker.models.containers.Container, "logs", mock_container)
 
     fire.Fire(
-        stardist_simple,
+        stardist_simple_cli,
         [
             "--slide-urlpath",
             "tests/testdata/pathology/123.svs",

--- a/tests/luna/pathology/cli/test_slide_etl.py
+++ b/tests/luna/pathology/cli/test_slide_etl.py
@@ -64,7 +64,7 @@ def test_slide_etl(tmp_path, dask_client):
     print(df)
 
     assert df.loc["123", "slide_size"] == 1938955
-    # assert df.loc["123", "properties.aperio.AppMag"] == 20
+    assert df.loc["123", "properties.aperio.AppMag"] == 20
     assert df.loc["123", "url"] == "file://" + os.path.join(tmp_path, "123.svs")
 
     assert os.path.exists(os.path.join(tmp_path, "123.svs"))
@@ -95,7 +95,7 @@ def test_slide_etl_subset(tmp_path, dask_client):
     print(df)
 
     assert df.loc["123", "slide_size"] == 1938955
-    # assert df.loc["123", "properties.aperio.AppMag"] == 20
+    assert df.loc["123", "properties.aperio.AppMag"] == 20
     assert df.loc["123", "url"] == "file://" + os.path.join(tmp_path, "123.svs")
 
     assert os.path.exists(os.path.join(tmp_path, "123.svs"))

--- a/tests/luna/pathology/cli/test_slide_etl.py
+++ b/tests/luna/pathology/cli/test_slide_etl.py
@@ -64,7 +64,7 @@ def test_slide_etl(tmp_path, dask_client):
     print(df)
 
     assert df.loc["123", "slide_size"] == 1938955
-    assert df.loc["123", "properties.aperio.AppMag"] == 20
+    # assert df.loc["123", "properties.aperio.AppMag"] == 20
     assert df.loc["123", "url"] == "file://" + os.path.join(tmp_path, "123.svs")
 
     assert os.path.exists(os.path.join(tmp_path, "123.svs"))
@@ -95,7 +95,7 @@ def test_slide_etl_subset(tmp_path, dask_client):
     print(df)
 
     assert df.loc["123", "slide_size"] == 1938955
-    assert df.loc["123", "properties.aperio.AppMag"] == 20
+    # assert df.loc["123", "properties.aperio.AppMag"] == 20
     assert df.loc["123", "url"] == "file://" + os.path.join(tmp_path, "123.svs")
 
     assert os.path.exists(os.path.join(tmp_path, "123.svs"))

--- a/tests/testdata/pathology/heatmap_config.yml
+++ b/tests/testdata/pathology/heatmap_config.yml
@@ -1,6 +1,5 @@
 input_urlpath: tests/testdata/pathology/tile_scores.csv
 image_filename: 123.svs
-output_urlpath: tests/luna/pathology/cli/testouts
 annotation_name: test
 tile_size: 128
 scale_factor: 8

--- a/tests/testdata/pathology/stardist_cell.yml
+++ b/tests/testdata/pathology/stardist_cell.yml
@@ -1,6 +1,5 @@
 input_urlpath: tests/testdata/pathology/test_object_detection.tsv
 image_filename: 123.svs
-output_urlpath: tests/luna/pathology/cli/testouts
 annotation_name: Points of Classsified StarDist Cells
 line_colors:
   Other: rgb(0, 255, 0)

--- a/tests/testdata/pathology/stardist_cell_detection/metadata.yml
+++ b/tests/testdata/pathology/stardist_cell_detection/metadata.yml
@@ -1,12 +1,19 @@
-cell_expansion_size: 8.0
-cell_objects: tests/testdata/pathology/stardist_cell_detection/123_cell_objects.parquet
+cell_expansion_size: 8
 debug_opts: ''
-feature_data: tests/testdata/pathology/stardist_cell_detection/123_cell_objects.parquet
+geojson_url: file:///gpfs/mskmind_ess/limr/repos/luna/tests/testdata/pathology/stardist_cell_detection/cell_detections.geojson
+image: mskmind/qupath-stardist:0.4.3
 image_type: BRIGHTFIELD_H_DAB
-input_slide_image: /Users/limr/repos/luna/tests/testdata/pathology/123.svs
-num_cores: 4
-output_dir: tests/testdata/pathology/stardist_cell_detection
-segment_keys:
-  slide_id: '123'
+local_config: ''
+max_heap_size: 64G
+num_cores: 1
+output_filesystem: file
+output_storage_options:
+  auto_mkdir: true
+output_urlpath: tests/testdata/pathology/stardist_cell_detection
+parquet_url: file:///gpfs/mskmind_ess/limr/repos/luna/tests/testdata/pathology/stardist_cell_detection/776c7630596bf071cf44e2f301e1502c986402251bdfbd8c1e5d7b2168001b8d_cell_objects.parquet
+slide_urlpath: tests/testdata/pathology/123.svs
 spatial: true
+storage_options: {}
 total_cells: 9
+tsv_url: file:///gpfs/mskmind_ess/limr/repos/luna/tests/testdata/pathology/stardist_cell_detection/cell_detections.tsv
+use_singularity: false

--- a/tests/testdata/pathology/stardist_polygon.yml
+++ b/tests/testdata/pathology/stardist_polygon.yml
@@ -1,6 +1,5 @@
 input_urlpath: tests/testdata/pathology/test_object_classification.geojson
 image_filename: 123.svs
-output_urlpath: tests/luna/pathology/cli/testouts
 annotation_name: StarDist Segmentations with Lymphocyte Classifications
 line_colors:
   Other: rgb(0, 255, 0)


### PR DESCRIPTION
This makes the Slide Manifest (from slide_etl) the main data frame of record for a project. Additional columns are added for annotations, and the tiles_url column is modified when tiles are generated, tissue is detected, and tiles are saved in the h5 store. Dask is used at the slide and tile level with batches for parallelizing when possible.

Currently, the tile tissue inference doesn't work with Dask, as we need to use a Dask-ML compatible library, i.e., Skorch. 

We also need some additional unit tests for the API functions.